### PR TITLE
fix: remove unregistered internal packages from install_requires (dependency confusion)

### DIFF
--- a/src/vibe_agent/setup.py
+++ b/src/vibe_agent/setup.py
@@ -27,8 +27,6 @@ setup(
         "dapr-ext-grpc~=1.12.0",
         "redis~=4.6.0",
         "hiredis~=2.2.0",
-        "vibe-core",
-        "vibe-common",
     ],
     entry_points={
         "console_scripts": [

--- a/src/vibe_common/setup.py
+++ b/src/vibe_common/setup.py
@@ -24,7 +24,6 @@ setup(
         "dapr~=1.13.0",
         "fastapi_utils~=0.2.1",
         "pyyaml~=6.0.1",
-        "vibe_core",
         "debugpy",
         "azure-identity~=1.14.0",
         "azure-storage-blob>=12.5.0",

--- a/src/vibe_notebook/setup.py
+++ b/src/vibe_notebook/setup.py
@@ -16,6 +16,5 @@ setup(
         "pandas",
         "shapely",
         "rasterio",
-        "vibe_core",
     ],
 )

--- a/src/vibe_server/setup.py
+++ b/src/vibe_server/setup.py
@@ -14,8 +14,6 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     python_requires="~=3.8",
     install_requires=[
-        "vibe-core",
-        "vibe-common",
         "httpx~=0.24.1",
         "fastapi_utils~=0.2.1",
         "grpcio~=1.53.0",


### PR DESCRIPTION
Four `setup.py` files in this repo declare internal packages (`vibe-core`, `vibe-common`, `vibe_core`) as `install_requires` dependencies using their bare PyPI-style names. None of these package names are registered on PyPI.

Because they appear in `install_requires`, pip resolves them transitively from PyPI when any of the affected packages is installed. An attacker who registers `vibe-core` or `vibe-common` on PyPI (PEP 503 normalisation means one registration covers both spellings) gains code execution in any environment installing `vibe_agent`, `vibe_common`, `vibe_server`, or `vibe_notebook`.

This PR removes the four unregistered names from `install_requires` in:
- `src/vibe_agent/setup.py` — removes `vibe-core`, `vibe-common`
- `src/vibe_common/setup.py` — removes `vibe_core`
- `src/vibe_server/setup.py` — removes `vibe-core`, `vibe-common`
- `src/vibe_notebook/setup.py` — removes `vibe_core`

**Security impact:** A single PyPI registration compromises all four components simultaneously and gives the attacker access to the Azure credentials (identity tokens, storage keys, Cosmos DB connections) these packages are configured to use.
