### PR TITLE
Fix #226: resolve Pydantic v1 recursion in RunDetails instantiation

### DIFF
--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import os
 from argparse import ArgumentParser, Namespace
+from copy import copy
 from dataclasses import asdict
 from datetime import datetime
 from enum import auto
@@ -128,6 +129,8 @@ class TerravibesProvider:
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.state_store = StateStore()
         self.href_handler = href_handler
+        # Cache "empty" RunDetails because creating it triggers the big bad bug
+        self._pending_details = asdict(RunDetails())
 
     @add_trace
     def summarize_runs(self, runs: List[RunConfig], fields: List[str] = SUMMARY_DEFAULT_FIELDS):
@@ -448,9 +451,9 @@ class TerravibesProvider:
 
         workflow_data = {k: v for k, v in asdict(workflow).items() if k != "user_input"}
         workflow_data["id"] = new_id
-        workflow_data["details"] = RunDetails()  # type: ignore
-        # Set workflow submission time
-        workflow_data["details"].submission_time = datetime.utcnow()
+        details = copy(self._pending_details)
+        details["submission_time"] = datetime.utcnow()
+        workflow_data["details"] = details
         workflow_data["task_details"] = {}
         workflow_data["user_input"] = workflow.user_input
         if isinstance(workflow.user_input, SpatioTemporalJson):


### PR DESCRIPTION
## Summary
Fixes #226

## Problem
The FarmVibes.AI Python client throws a RecursionError 
when triggering workflows on the remote AKS cluster. 

Root cause: RunDetails() was triggering recursive __init__ 
wrapping in Pydantic v1 when instantiated repeatedly in 
server.py. Each instantiation wrapped the previous __init__, 
causing a stack overflow on repeated workflow calls.

## Fix
Applied the same fix pattern already present in 
orchestrator.py (by the original authors) — cached an empty 
RunDetails instance using asdict() and copy() instead of 
creating a new RunDetails() on every call, avoiding the 
recursive Pydantic wrapping entirely.

## Files Changed
- src/vibe_server/vibe_server/server.py (6 lines)

## Validation
- Identical pattern to existing fix in orchestrator.py
- No other production code has the same bug pattern  
- No compile or lint errors in the changed file
- Full integration testing handled by CI/CD on PR creation

## Co-authors
Co-authored-by: nik464 <nikhil18chaudhary@gmail.com>