### PR TITLE
Block unsafe external references

### DIFF
--- a/ops/download_from_ref/download_from_ref.py
+++ b/ops/download_from_ref/download_from_ref.py
@@ -6,12 +6,14 @@ import ipaddress
 import mimetypes
 import os
 import pathlib
-import shutil
 import socket
 from dataclasses import fields
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Type, cast, get_origin
-from urllib.parse import urljoin, urlparse
+from urllib.parse import ParseResult, urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
 
 from vibe_core.data import (
     AssetVibe,
@@ -20,49 +22,91 @@ from vibe_core.data import (
     data_registry,
     gen_hash_id,
 )
-from vibe_core.file_downloader import download_file
-from vibe_core.uri import is_local, local_uri_to_path, uri_to_filename
+from vibe_core.file_downloader import download_file, retry_session
+from vibe_core.uri import uri_to_filename
 
 CHUNK_SIZE_BYTES = 1024 * 1024
 
 ALLOWED_SCHEMES = ("http", "https")
 
 
-def check_url(url: str) -> None:
-    """Reject references that make the worker read local files or reach internal hosts.
-
-    The url comes straight from user input, so without this the op is an arbitrary file
-    read and a full-read SSRF against anything the worker can reach (CWE-918).
-
-    Raises:
-        ValueError: If the URL is not an http(s) URL pointing to a public address.
-    """
+def parse_external_url(url: str) -> ParseResult:
     parsed = urlparse(url)
     if parsed.scheme not in ALLOWED_SCHEMES or not parsed.hostname:
         raise ValueError(
             f"Refusing to fetch reference {url!r}: only {'/'.join(ALLOWED_SCHEMES)} URLs "
             "are supported."
         )
+    return parsed
+
+
+def resolve_public_address(url: str) -> str:
+    """Resolve an external URL to one validated public address."""
+    parsed = parse_external_url(url)
 
     try:
         addresses = socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)
     except socket.gaierror as e:
         raise ValueError(f"Refusing to fetch reference {url!r}: could not resolve host") from e
 
-    for address in addresses:
-        ip = ipaddress.ip_address(address[4][0])
+    resolved = [ipaddress.ip_address(address[4][0]) for address in addresses]
+    if not resolved:
+        raise ValueError(f"Refusing to fetch reference {url!r}: host resolved to no addresses")
+    for ip in resolved:
         if not ip.is_global or ip.is_multicast:
             raise ValueError(
                 f"Refusing to fetch reference {url!r}: host resolves to non-public address {ip}."
             )
+    return str(resolved[0])
 
 
-def check_redirect(response: Any, *args: Any, **kwargs: Any) -> Any:
-    """Validate redirect targets before requests follows them."""
-    location = response.headers.get("location")
-    if response.is_redirect and location:
-        check_url(urljoin(response.url, location))
-    return response
+class PinnedAddressAdapter(HTTPAdapter):
+    """Connect to a validated address without resolving the hostname again."""
+
+    def connection_for_url(self, url: str, proxies: Any = None) -> Any:
+        if proxies:
+            raise ValueError("Proxies are not supported for external references")
+
+        parsed = urlparse(url)
+        address = resolve_public_address(url)
+        pool_kwargs = (
+            {"assert_hostname": parsed.hostname, "server_hostname": parsed.hostname}
+            if parsed.scheme == "https"
+            else {}
+        )
+        return self.poolmanager.connection_from_host(
+            address, port=parsed.port, scheme=parsed.scheme, pool_kwargs=pool_kwargs
+        )
+
+    def _get_connection(
+        self, request: Any, verify: Any, proxies: Any = None, cert: Any = None
+    ) -> Any:
+        return self.connection_for_url(request.url, proxies)
+
+    def get_connection_with_tls_context(
+        self, request: Any, verify: Any, proxies: Any = None, cert: Any = None
+    ) -> Any:
+        return self.connection_for_url(request.url, proxies)
+
+    def get_connection(self, url: str, proxies: Any = None) -> Any:
+        return self.connection_for_url(url, proxies)
+
+    def add_headers(self, request: Any, **kwargs: Any) -> None:
+        super().add_headers(request, **kwargs)
+        parsed = urlparse(request.url)
+        host = cast(str, parsed.hostname)
+        host = f"[{host}]" if ":" in host else host
+        if parsed.port and parsed.port != {"http": 80, "https": 443}[parsed.scheme]:
+            host = f"{host}:{parsed.port}"
+        request.headers["Host"] = host
+
+
+def pinned_session() -> requests.Session:
+    adapter = PinnedAddressAdapter()
+    session = retry_session(adapter)
+    session.mount("", adapter)
+    session.trust_env = False
+    return session
 
 
 def hash_file(filepath: str, chunk_size: int = CHUNK_SIZE_BYTES) -> str:
@@ -102,12 +146,10 @@ class CallbackBuilder:
     def __call__(self):
         def callback(input_ref: ExternalReference) -> Dict[str, DataVibe]:
             # Download the file
-            check_url(input_ref.url)
+            parse_external_url(input_ref.url)
             out_path = os.path.join(self.tmp_dir.name, uri_to_filename(input_ref.url))
-            if is_local(input_ref.url):
-                shutil.copy(local_uri_to_path(input_ref.url), out_path)
-            else:
-                download_file(input_ref.url, out_path, hooks={"response": check_redirect})
+            with pinned_session() as session:
+                download_file(input_ref.url, out_path, session=session)
 
             file_extension = pathlib.Path(out_path).suffix
             if file_extension not in mimetypes.types_map.keys():

--- a/ops/download_from_ref/download_from_ref.py
+++ b/ops/download_from_ref/download_from_ref.py
@@ -27,6 +27,7 @@ CHUNK_SIZE_BYTES = 1024 * 1024
 
 ALLOWED_SCHEMES = ("http", "https")
 
+
 def check_url(url: str) -> None:
     """Reject references that make the worker read local files or reach internal hosts.
 

--- a/ops/download_from_ref/download_from_ref.py
+++ b/ops/download_from_ref/download_from_ref.py
@@ -2,13 +2,16 @@
 # Licensed under the MIT License.
 
 import hashlib
+import ipaddress
 import mimetypes
 import os
 import pathlib
 import shutil
+import socket
 from dataclasses import fields
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Type, cast, get_origin
+from urllib.parse import urljoin, urlparse
 
 from vibe_core.data import (
     AssetVibe,
@@ -21,6 +24,44 @@ from vibe_core.file_downloader import download_file
 from vibe_core.uri import is_local, local_uri_to_path, uri_to_filename
 
 CHUNK_SIZE_BYTES = 1024 * 1024
+
+ALLOWED_SCHEMES = ("http", "https")
+
+def check_url(url: str) -> None:
+    """Reject references that make the worker read local files or reach internal hosts.
+
+    The url comes straight from user input, so without this the op is an arbitrary file
+    read and a full-read SSRF against anything the worker can reach (CWE-918).
+
+    Raises:
+        ValueError: If the URL is not an http(s) URL pointing to a public address.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ALLOWED_SCHEMES or not parsed.hostname:
+        raise ValueError(
+            f"Refusing to fetch reference {url!r}: only {'/'.join(ALLOWED_SCHEMES)} URLs "
+            "are supported."
+        )
+
+    try:
+        addresses = socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise ValueError(f"Refusing to fetch reference {url!r}: could not resolve host") from e
+
+    for address in addresses:
+        ip = ipaddress.ip_address(address[4][0])
+        if not ip.is_global or ip.is_multicast:
+            raise ValueError(
+                f"Refusing to fetch reference {url!r}: host resolves to non-public address {ip}."
+            )
+
+
+def check_redirect(response: Any, *args: Any, **kwargs: Any) -> Any:
+    """Validate redirect targets before requests follows them."""
+    location = response.headers.get("location")
+    if response.is_redirect and location:
+        check_url(urljoin(response.url, location))
+    return response
 
 
 def hash_file(filepath: str, chunk_size: int = CHUNK_SIZE_BYTES) -> str:
@@ -60,11 +101,12 @@ class CallbackBuilder:
     def __call__(self):
         def callback(input_ref: ExternalReference) -> Dict[str, DataVibe]:
             # Download the file
+            check_url(input_ref.url)
             out_path = os.path.join(self.tmp_dir.name, uri_to_filename(input_ref.url))
             if is_local(input_ref.url):
                 shutil.copy(local_uri_to_path(input_ref.url), out_path)
             else:
-                download_file(input_ref.url, out_path)
+                download_file(input_ref.url, out_path, hooks={"response": check_redirect})
 
             file_extension = pathlib.Path(out_path).suffix
             if file_extension not in mimetypes.types_map.keys():

--- a/ops/download_from_ref/test_download_from_ref.py
+++ b/ops/download_from_ref/test_download_from_ref.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import threading
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Iterator, List
+
+import pytest
+from download_from_ref import CallbackBuilder, check_redirect
+from vibe_core.data import ExternalReference
+from vibe_core.file_downloader import download_file
+
+HITS: List[str] = []
+
+
+def make_ref(url: str) -> ExternalReference:
+    now = datetime.now()
+    return ExternalReference(
+        id="test_id",
+        time_range=(now, now),
+        geometry={"type": "Point", "coordinates": [0.0, 0.0]},
+        assets=[],
+        url=url,
+    )
+
+
+def make_handler(redirect_to: str = ""):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            HITS.append(self.path)
+            if redirect_to:
+                self.send_response(302)
+                self.send_header("Location", redirect_to)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args: Any):
+            pass
+
+    return Handler
+
+
+@pytest.fixture
+def redirect_to_internal() -> Iterator[str]:
+    """Serve a url that redirects into another (internal) host, recording every request."""
+    internal = HTTPServer(("127.0.0.1", 0), make_handler())
+    attacker = HTTPServer(
+        ("127.0.0.1", 0), make_handler(f"http://127.0.0.1:{internal.server_port}/x")
+    )
+    for server in (internal, attacker):
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+    HITS.clear()
+    yield f"http://127.0.0.1:{attacker.server_port}/redirect"
+    for server in (internal, attacker):
+        server.shutdown()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",  # arbitrary local file read
+        "/etc/passwd",
+        "ftp://example.com/raster.tif",
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata service
+        "http://127.0.0.1:8080/secret",
+        "http://10.0.0.5/secret",
+        "http://[::1]/secret",
+    ],
+)
+def test_op_refuses_unsafe_refs(url: str):
+    with pytest.raises(ValueError):
+        CallbackBuilder("Raster")()(make_ref(url))
+
+
+def test_redirect_into_internal_host_is_not_issued(redirect_to_internal: str, tmp_path: Any):
+    with pytest.raises(ValueError):
+        download_file(
+            redirect_to_internal, str(tmp_path / "out"), hooks={"response": check_redirect}
+        )
+    assert HITS == ["/redirect"], f"the redirect hop should never be issued, got {HITS}"

--- a/ops/download_from_ref/test_download_from_ref.py
+++ b/ops/download_from_ref/test_download_from_ref.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, List
 
 import pytest
 from download_from_ref import CallbackBuilder, check_redirect
+
 from vibe_core.data import ExternalReference
 from vibe_core.file_downloader import download_file
 

--- a/ops/download_from_ref/test_download_from_ref.py
+++ b/ops/download_from_ref/test_download_from_ref.py
@@ -1,18 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import ipaddress
+import socket
 import threading
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Iterator, List
+from typing import Any, Iterator, List, Tuple
+from unittest.mock import Mock
 
+import download_from_ref
 import pytest
-from download_from_ref import CallbackBuilder, check_redirect
+from download_from_ref import CallbackBuilder, PinnedAddressAdapter, pinned_session
 
 from vibe_core.data import ExternalReference
 from vibe_core.file_downloader import download_file
 
-HITS: List[str] = []
+HITS: List[Tuple[str, str, str]] = []
 
 
 def make_ref(url: str) -> ExternalReference:
@@ -26,17 +30,18 @@ def make_ref(url: str) -> ExternalReference:
     )
 
 
-def make_handler(redirect_to: str = ""):
+def make_handler(name: str, redirect_to: str = "", body: bytes = b""):
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):
-            HITS.append(self.path)
+            HITS.append((name, self.path, self.headers["Host"]))
             if redirect_to:
                 self.send_response(302)
                 self.send_header("Location", redirect_to)
             else:
                 self.send_response(200)
-                self.send_header("Content-Length", "0")
+                self.send_header("Content-Length", str(len(body)))
             self.end_headers()
+            self.wfile.write(body)
 
         def log_message(self, *args: Any):
             pass
@@ -47,16 +52,18 @@ def make_handler(redirect_to: str = ""):
 @pytest.fixture
 def redirect_to_internal() -> Iterator[str]:
     """Serve a url that redirects into another (internal) host, recording every request."""
-    internal = HTTPServer(("127.0.0.1", 0), make_handler())
+    internal = HTTPServer(("127.0.0.1", 0), make_handler("internal"))
     attacker = HTTPServer(
-        ("127.0.0.1", 0), make_handler(f"http://127.0.0.1:{internal.server_port}/x")
+        ("127.0.0.1", 0),
+        make_handler("attacker", f"http://127.0.0.1:{internal.server_port}/x"),
     )
     for server in (internal, attacker):
         threading.Thread(target=server.serve_forever, daemon=True).start()
     HITS.clear()
-    yield f"http://127.0.0.1:{attacker.server_port}/redirect"
+    yield f"http://attacker.test:{attacker.server_port}/redirect"
     for server in (internal, attacker):
         server.shutdown()
+        server.server_close()
 
 
 @pytest.mark.parametrize(
@@ -76,9 +83,84 @@ def test_op_refuses_unsafe_refs(url: str):
         CallbackBuilder("Raster")()(make_ref(url))
 
 
-def test_redirect_into_internal_host_is_not_issued(redirect_to_internal: str, tmp_path: Any):
+def test_redirect_into_internal_host_is_not_issued(
+    redirect_to_internal: str, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+):
+    original_resolver = download_from_ref.resolve_public_address
+
+    def resolve_attacker(url: str) -> str:
+        if download_from_ref.urlparse(url).hostname == "attacker.test":
+            return "127.0.0.1"
+        return original_resolver(url)
+
+    monkeypatch.setattr(download_from_ref, "resolve_public_address", resolve_attacker)
     with pytest.raises(ValueError):
-        download_file(
-            redirect_to_internal, str(tmp_path / "out"), hooks={"response": check_redirect}
-        )
-    assert HITS == ["/redirect"], f"the redirect hop should never be issued, got {HITS}"
+        with pinned_session() as session:
+            download_file(redirect_to_internal, str(tmp_path / "out"), session=session)
+    assert [hit[0] for hit in HITS] == ["attacker"]
+
+
+def test_dns_rebinding_cannot_change_connection(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+):
+    safe = HTTPServer(("127.0.0.1", 0), make_handler("safe", body=b"safe"))
+    victim = HTTPServer(("127.0.0.2", safe.server_port), make_handler("victim", body=b"victim"))
+    for server in (safe, victim):
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    real_getaddrinfo = socket.getaddrinfo
+    real_ip_address = ipaddress.ip_address
+    dns_calls = 0
+
+    def rebind(host: str, *args: Any, **kwargs: Any):
+        nonlocal dns_calls
+        if host == "rebind.test":
+            address = "127.0.0.1" if dns_calls == 0 else "127.0.0.2"
+            dns_calls += 1
+            port = args[0] if args else 0
+            return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (address, port))]
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    def allow_test_loopback(address: str):
+        parsed = real_ip_address(address)
+        if not str(parsed).startswith("127."):
+            return parsed
+
+        class PublicLoopback:
+            is_global = True
+            is_multicast = False
+
+            def __str__(self):
+                return str(parsed)
+
+        return PublicLoopback()
+
+    monkeypatch.setattr(download_from_ref.socket, "getaddrinfo", rebind)
+    monkeypatch.setattr(download_from_ref.ipaddress, "ip_address", allow_test_loopback)
+    HITS.clear()
+    try:
+        url = f"http://rebind.test:{safe.server_port}/asset.tif"
+        with pinned_session() as session:
+            download_file(url, str(tmp_path / "out"), session=session)
+        assert (tmp_path / "out").read_bytes() == b"safe"
+        assert dns_calls == 1
+        assert HITS == [("safe", "/asset.tif", f"rebind.test:{safe.server_port}")]
+    finally:
+        for server in (safe, victim):
+            server.shutdown()
+            server.server_close()
+
+
+def test_https_pinning_preserves_tls_hostname(monkeypatch: pytest.MonkeyPatch):
+    adapter = PinnedAddressAdapter()
+    adapter.poolmanager = Mock()
+    monkeypatch.setattr(download_from_ref, "resolve_public_address", lambda url: "93.184.216.34")
+
+    adapter.connection_for_url("https://example.com/file")
+
+    adapter.poolmanager.connection_from_host.assert_called_once_with(
+        "93.184.216.34",
+        port=None,
+        scheme="https",
+        pool_kwargs={"assert_hostname": "example.com", "server_hostname": "example.com"},
+    )

--- a/src/vibe_core/vibe_core/file_downloader.py
+++ b/src/vibe_core/vibe_core/file_downloader.py
@@ -6,7 +6,7 @@
 import logging
 import mimetypes
 import os
-from typing import Any
+from typing import Any, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -30,7 +30,7 @@ READ_TIMEOUT_S = 30
 LOGGER = logging.getLogger(__name__)
 
 
-def retry_session() -> requests.Session:
+def retry_session(adapter: Optional[HTTPAdapter] = None) -> requests.Session:
     """Create a session with retry support.
 
     This method creates a requests.Session object with retry support
@@ -51,7 +51,9 @@ def retry_session() -> requests.Session:
 
     # Had to ignore the type as urlib is loaded dinamically
     # details here (https://github.com/microsoft/pylance-release/issues/597)
-    adapter = HTTPAdapter(max_retries=retry)  # type: ignore
+    if adapter is None:
+        adapter = HTTPAdapter()  # type: ignore
+    adapter.max_retries = retry
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
@@ -86,6 +88,7 @@ def download_file(
     chunk_size: int = CHUNK_SIZE,
     connect_timeout: float = CONNECT_TIMEOUT_S,
     read_timeout: float = READ_TIMEOUT_S,  # applies per chunk
+    session: Optional[requests.Session] = None,
     **kwargs: Any,
 ) -> str:
     """Download a file from a given URL to the given file path.
@@ -101,15 +104,18 @@ def download_file(
             (defaults to :const:`CONNECT_TIMEOUT_S`).
         read_timeout: Time in seconds for each chunk read from the server
             (defaults to :const:`READ_TIMEOUT_S`).
+        session: Optional preconfigured requests session.
         kwargs: Additional keyword arguments to be passed to the request library call.
 
     Returns:
         Path of the saved file.
     """
-    session = retry_session()
+    download_session = session if session is not None else retry_session()
 
     try:
-        with session.get(url, stream=True, timeout=(connect_timeout, read_timeout), **kwargs) as r:
+        with download_session.get(
+            url, stream=True, timeout=(connect_timeout, read_timeout), **kwargs
+        ) as r:
             r.raise_for_status()
             with open(file_path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=chunk_size):


### PR DESCRIPTION
`download_from_ref` accepted user-controlled local paths and arbitrary URLs. That allowed workflows to read files from the worker or request internal services, including cloud metadata endpoints.

This PR restricts references to HTTP(S) URLs resolving only to public addresses. Redirect targets are checked before they are followed, so redirects cannot bypass the restriction.