### PR TITLE
Bounded run history

### DIFF
--- a/docs/source/docfiles/markdown/CLIENT.md
+++ b/docs/source/docfiles/markdown/CLIENT.md
@@ -336,6 +336,13 @@ starts and when workflow creation or deletion events are received.
 For local Redis, a prefix scan is used only when an older run record predates the stored task-name
 list needed to remove its legacy task keys.
 
+These defaults are enabled only for local Redis deployments. Updating an existing local cluster
+starts applying them immediately, so the first data-ops startup can compact or delete the oldest
+eligible terminal history. Pass larger limits to `local update` if more existing history must be
+retained. A zero value disables that retention tier rather than maintenance; setting both limits
+to zero deletes every eligible terminal run after cleanup. Non-default limits must be supplied
+again on later `local update` commands; omitted flags reapply the defaults.
+
 For a local cluster, configure both tiers during setup or update:
 
 ```console

--- a/docs/source/docfiles/markdown/CLIENT.md
+++ b/docs/source/docfiles/markdown/CLIENT.md
@@ -313,10 +313,11 @@ For more information on how data in managed and cached in FarmVibes.AI, please r
 
 FarmVibes.AI bounds durable workflow history by default:
 
-- The newest 100 runs retain their complete run output and per-task state.
-- Up to 900 older terminal runs are retained as compact summaries.
-- Older terminal runs are automatically deleted after the normal data/cache reference cleanup
-  completes. Their run record, task keys, and entry in the run list are then removed atomically.
+- The newest 100 positions in the run index retain complete run output and per-task state.
+- Eligible terminal runs in the preceding 900 positions are retained as compact summaries.
+- Eligible terminal runs in older positions are automatically deleted after the normal data/cache
+  reference cleanup completes. Their run record, task keys, and entry in the run list are then
+  removed atomically.
 
 Active runs (`pending`, `queued`, or `running`) and runs already being deleted are never compacted
 or selected for retention deletion. They can therefore temporarily make the history larger than
@@ -330,9 +331,10 @@ and task/subtask details are no longer available: detail responses return empty 
 `task_details` objects. Cached assets remain referenced until the compact summary is eventually
 deleted.
 
-The defaults keep 1,000 terminal history entries while limiting potentially large outputs and task
-graphs to the 100 most recent runs. Maintenance runs in bounded passes when the data-ops service
-starts and when workflow creation or deletion events are received.
+The defaults divide the newest 1,000 run-index positions into full and compact tiers while limiting
+potentially large outputs and task graphs to the 100 newest positions. Active or deleting runs still
+occupy positions but are skipped. Maintenance runs in bounded passes at startup, every 60 seconds,
+and when workflow creation or deletion events are received.
 For local Redis, a prefix scan is used only when an older run record predates the stored task-name
 list needed to remove its legacy task keys.
 

--- a/docs/source/docfiles/markdown/CLIENT.md
+++ b/docs/source/docfiles/markdown/CLIENT.md
@@ -308,3 +308,41 @@ deletion is successful, all cached data the workflow run produced that is not sh
 workflow runs will be deleted and status will be set to `deleted`.
 
 For more information on how data in managed and cached in FarmVibes.AI, please refer to our [Data Management user guide](./CACHE.md).
+
+## Run history retention
+
+FarmVibes.AI bounds durable workflow history by default:
+
+- The newest 100 runs retain their complete run output and per-task state.
+- Up to 900 older terminal runs are retained as compact summaries.
+- Older terminal runs are automatically deleted after the normal data/cache reference cleanup
+  completes. Their run record, task keys, and entry in the run list are then removed atomically.
+
+Active runs (`pending`, `queued`, or `running`) and runs already being deleted are never compacted
+or selected for retention deletion. They can therefore temporarily make the history larger than
+the configured limits. If retention cleanup was already started and interrupted, a later pass
+resumes that cleanup but still waits for the `deleted` state before removing history keys.
+
+A compact summary has `history_compacted=true`. It preserves the run id, name, workflow,
+parameters, user input, spatio-temporal input, status, timestamps, and failure/cancellation reason,
+so listing, describing, resubmitting, and explicitly deleting the run remain supported. Run output
+and task/subtask details are no longer available: detail responses return empty `output` and
+`task_details` objects. Cached assets remain referenced until the compact summary is eventually
+deleted.
+
+The defaults keep 1,000 terminal history entries while limiting potentially large outputs and task
+graphs to the 100 most recent runs. Maintenance runs in bounded passes when the data-ops service
+starts and when workflow creation or deletion events are received.
+For local Redis, a prefix scan is used only when an older run record predates the stored task-name
+list needed to remove its legacy task keys.
+
+For a local cluster, configure both tiers during setup or update:
+
+```console
+farmvibes-ai local update \
+  --max-full-history-runs 100 \
+  --max-compact-history-runs 900
+```
+
+The data-ops service exposes the same settings as
+`data_ops.impl.max_full_history_runs` and `data_ops.impl.max_compact_history_runs`.

--- a/src/tests/test_rest_api.py
+++ b/src/tests/test_rest_api.py
@@ -123,23 +123,24 @@ def test_workflow_submission(
 
 
 @patch.object(TerravibesProvider, "submit_work")
-@patch.object(
-    StateStore,
-    "transaction",
-    side_effect=[StateStoreConflictError("simulated conflict"), None],
-)
-@patch.object(
-    StateStore,
-    "retrieve_with_etag",
-    side_effect=[(["older"], "1"), (["concurrent"], "2")],
-)
+@patch.object(StateStore, "transaction")
+@patch.object(StateStore, "retrieve_with_etag")
 def test_workflow_submission_retries_run_index_conflict(
-    _: MagicMock,
+    retrieve_with_etag: MagicMock,
     transaction: MagicMock,
     __: MagicMock,
     workflow_run_config: Dict[str, Any],
     request_client: requests.Session,
 ):
+    concurrent_ids = ["concurrent"]
+    retrieve_with_etag.side_effect = [(["older"], "1"), (concurrent_ids, "2")]
+
+    async def conflict_after_commit(operations: List[Dict[str, Any]]):
+        if transaction.await_count == 1:
+            concurrent_ids.append(operations[0]["value"][-1])
+            raise StateStoreConflictError("simulated ambiguous conflict")
+
+    transaction.side_effect = conflict_after_commit
     response = request_client.post("/v0/runs", json=workflow_run_config)
 
     assert response.status_code == 201

--- a/src/tests/test_rest_api.py
+++ b/src/tests/test_rest_api.py
@@ -85,27 +85,32 @@ def test_generate_api_documentation_page(request_client: requests.Session):
 
 @pytest.mark.parametrize("params", [None, {"param1": "new_param"}])
 @patch("vibe_server.server.send", return_value="OK")
+@patch.object(StateStore, "store_if_absent")
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
 @patch.object(StateStore, "retrieve_bulk", side_effect=lambda _: [])
-@patch.object(StateStore, "retrieve_with_etag", side_effect=lambda _: ([], None))
+@patch.object(StateStore, "retrieve_with_etag")
 def test_workflow_submission(
-    _: MagicMock,
+    retrieve_with_etag: MagicMock,
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    store_if_absent: MagicMock,
     send: MagicMock,
     workflow_run_config: Dict[str, Any],
     params: Dict[str, Any],
     request_client: requests.Session,
 ):
+    retrieve_with_etag.side_effect = [([], None), ([], "1")]
     workflow_run_config["parameters"] = params
     response = request_client.post("/v0/runs", json=workflow_run_config)
     send.assert_called()
     assert send.call_args[0][0].content.parameters == params
 
     assert response.status_code == 201
+    store_if_absent.assert_awaited_once_with(RUNS_KEY, [])
     assert len(transaction.call_args.args[0]) == 2
+    assert transaction.call_args.args[0][0]["etag"] == "1"
     id = response.json()["id"]
     assert transaction.call_args.args[0][0]["value"][0] == id
     submitted_config = asdict(transaction.call_args.args[0][1]["value"])
@@ -156,9 +161,11 @@ def test_workflow_submission_retries_run_index_conflict(
     assert transaction.call_args_list[1].args[0][0]["etag"] == "2"
 
 
+@pytest.mark.parametrize("backend", ["redis", "cosmos"])
 @pytest.mark.anyio
 async def test_independent_providers_create_missing_run_index_without_lost_updates(
     workflow_run_config: Dict[str, Any],
+    backend: str,
 ):
     state: Dict[str, Any] = {}
     version = 0
@@ -166,7 +173,7 @@ async def test_independent_providers_create_missing_run_index_without_lost_updat
     all_read_missing = asyncio.Event()
     state_lock = asyncio.Lock()
 
-    async def retrieve_with_etag(key: str):
+    async def retrieve_with_etag(key: str, **_: Any):
         nonlocal missing_reads
         async with state_lock:
             if key in state:
@@ -181,14 +188,23 @@ async def test_independent_providers_create_missing_run_index_without_lost_updat
         value, _ = await retrieve_with_etag(key)
         return value
 
+    async def store_if_absent(key: str, value: Any):
+        nonlocal version
+        async with state_lock:
+            if key in state:
+                raise StateStoreConflictError(f"{backend} create conflict")
+            state[key] = deepcopy(value)
+            version += 1
+
     async def transaction(operations: List[Dict[str, Any]]):
         nonlocal version
         async with state_lock:
             index_operation = operations[0]
             etag = index_operation.get("etag")
-            current_etag = str(version) if RUNS_KEY in state else "-1"
-            if etag != current_etag:
-                raise StateStoreConflictError("etag mismatch")
+            if RUNS_KEY not in state:
+                raise RuntimeError(f"{backend} run index was not initialized")
+            if etag != str(version):
+                raise StateStoreConflictError(f"{backend} first-write conflict")
             for operation in operations:
                 state[operation["key"]] = deepcopy(operation.get("value"))
             version += 1
@@ -200,6 +216,7 @@ async def test_independent_providers_create_missing_run_index_without_lost_updat
     provider_stores = [StateStore(), StateStore()]
     for provider, store in zip(providers, provider_stores):
         store.retrieve_with_etag = AsyncMock(side_effect=retrieve_with_etag)
+        store.store_if_absent = AsyncMock(side_effect=store_if_absent)
         store.transaction = AsyncMock(side_effect=transaction)
         provider.state_store = store
 
@@ -223,9 +240,11 @@ async def test_independent_providers_create_missing_run_index_without_lost_updat
     assert len(run_ids) == 2
     assert startup_runs == []
     for store in provider_stores:
+        store.store_if_absent.assert_awaited_once_with(RUNS_KEY, [])
         first_index_write = store.transaction.call_args_list[0].args[0][0]
-        assert first_index_write["etag"] == "-1"
+        assert first_index_write["etag"]
         assert first_index_write["options"]["concurrency"] == "first-write"
+        assert first_index_write["options"]["consistency"] == "strong"
     startup_store.assert_not_awaited()
 
 
@@ -377,7 +396,7 @@ def test_missing_field_workflow_submission(
 @patch.object(
     TerravibesProvider,
     "list_runs_from_store_with_etag",
-    side_effect=lambda: ([], None),
+    side_effect=lambda: ([], "1"),
 )
 def test_submit_local_workflows_with_broken_work_submission(
     _, __: Any, ___: Any, workflow_run_config: Dict[str, Any], request_client: requests.Session
@@ -388,22 +407,26 @@ def test_submit_local_workflows_with_broken_work_submission(
 
 @patch("vibe_server.server.send", return_value="OK")
 @patch.object(TerravibesProvider, "submit_work")
+@patch.object(StateStore, "store_if_absent")
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
 @patch.object(StateStore, "retrieve_bulk")
-@patch.object(StateStore, "retrieve_with_etag", side_effect=lambda _: ([], None))
+@patch.object(StateStore, "retrieve_with_etag")
 def test_workflow_submission_and_cancellation(
     retrieve_with_etag: MagicMock,
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    store_if_absent: MagicMock,
     submit_work: MagicMock,
     send: MagicMock,
     workflow_run_config: Dict[str, Any],
     request_client: requests.Session,
 ):
+    retrieve_with_etag.side_effect = [([], None), ([], "1")]
     response = request_client.post("/v0/runs", json=workflow_run_config)
     assert response.status_code == 201
+    store_if_absent.assert_awaited_once_with(RUNS_KEY, [])
     assert len(transaction.call_args.args[0]) == 2
     id = response.json()["id"]
     assert transaction.call_args.args[0][0]["value"][0] == id
@@ -426,7 +449,7 @@ def test_workflow_submission_and_cancellation(
 @patch.object(
     TerravibesProvider,
     "list_runs_from_store_with_etag",
-    side_effect=lambda: ([], None),
+    side_effect=lambda: ([], "1"),
 )
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk", side_effect=lambda _: [])

--- a/src/tests/test_rest_api.py
+++ b/src/tests/test_rest_api.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import asyncio
+import json
 from copy import deepcopy
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
@@ -10,15 +11,17 @@ from uuid import uuid4 as uuid
 
 import pytest
 import requests
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from vibe_common.constants import CONTROL_STATUS_PUBSUB, WORKFLOW_REQUEST_PUBSUB_TOPIC
+from vibe_common.constants import CONTROL_STATUS_PUBSUB, RUNS_KEY, WORKFLOW_REQUEST_PUBSUB_TOPIC
 from vibe_common.messaging import WorkflowCancellationMessage
 from vibe_common.statestore import DEFAULT_BULK_PARALLELISM, StateStore, StateStoreConflictError
 from vibe_core.data.core_types import InnerIOType
 from vibe_core.data.utils import StacConverter, deserialize_stac
 from vibe_core.datamodel import RunConfig, RunConfigInput, RunDetails, RunStatus
 from vibe_server.href_handler import BlobHrefHandler, LocalHrefHandler
+from vibe_server.orchestrator import Orchestrator
 from vibe_server.server import TerravibesAPI, TerravibesProvider
 from vibe_server.workflow.input_handler import build_args_for_workflow
 from vibe_server.workflow.workflow import load_workflow_by_name
@@ -151,6 +154,79 @@ def test_workflow_submission_retries_run_index_conflict(
     assert transaction.call_args_list[0].args[0][0]["value"] == ["older", run_id]
     assert transaction.call_args_list[1].args[0][0]["value"] == ["concurrent", run_id]
     assert transaction.call_args_list[1].args[0][0]["etag"] == "2"
+
+
+@pytest.mark.anyio
+async def test_independent_providers_create_missing_run_index_without_lost_updates(
+    workflow_run_config: Dict[str, Any],
+):
+    state: Dict[str, Any] = {}
+    version = 0
+    missing_reads = 0
+    all_read_missing = asyncio.Event()
+    state_lock = asyncio.Lock()
+
+    async def retrieve_with_etag(key: str):
+        nonlocal missing_reads
+        async with state_lock:
+            if key in state:
+                return deepcopy(state[key]), str(version)
+            missing_reads += 1
+            if missing_reads == 3:
+                all_read_missing.set()
+        await all_read_missing.wait()
+        raise KeyError(key)
+
+    async def retrieve(key: str):
+        value, _ = await retrieve_with_etag(key)
+        return value
+
+    async def transaction(operations: List[Dict[str, Any]]):
+        nonlocal version
+        async with state_lock:
+            index_operation = operations[0]
+            etag = index_operation.get("etag")
+            current_etag = str(version) if RUNS_KEY in state else "-1"
+            if etag != current_etag:
+                raise StateStoreConflictError("etag mismatch")
+            for operation in operations:
+                state[operation["key"]] = deepcopy(operation.get("value"))
+            version += 1
+
+    providers = [
+        TerravibesProvider(LocalHrefHandler(".")),
+        TerravibesProvider(LocalHrefHandler(".")),
+    ]
+    provider_stores = [StateStore(), StateStore()]
+    for provider, store in zip(providers, provider_stores):
+        store.retrieve_with_etag = AsyncMock(side_effect=retrieve_with_etag)
+        store.transaction = AsyncMock(side_effect=transaction)
+        provider.state_store = store
+
+    orchestrator = Orchestrator()
+    orchestrator.statestore.retrieve = AsyncMock(side_effect=retrieve)
+    startup_store = AsyncMock()
+    orchestrator.statestore.store = startup_store
+
+    with patch.object(TerravibesProvider, "submit_work"):
+        first, second, startup_runs = await asyncio.gather(
+            providers[0].create_run(RunConfigInput(**deepcopy(workflow_run_config))),
+            providers[1].create_run(RunConfigInput(**deepcopy(workflow_run_config))),
+            orchestrator.get_unfinished_workflows(),
+        )
+
+    assert isinstance(first, JSONResponse)
+    assert isinstance(second, JSONResponse)
+    run_ids = {json.loads(response.body)["id"] for response in (first, second)}
+    assert first.status_code == second.status_code == 201
+    assert set(state[RUNS_KEY]) == run_ids
+    assert len(run_ids) == 2
+    assert startup_runs == []
+    for store in provider_stores:
+        first_index_write = store.transaction.call_args_list[0].args[0][0]
+        assert first_index_write["etag"] == "-1"
+        assert first_index_write["options"]["concurrency"] == "first-write"
+    startup_store.assert_not_awaited()
 
 
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
@@ -371,7 +447,7 @@ def test_workflow_resubmission(
         nonlocal submitted_runs
         submitted_runs.append(run)
 
-    def update_run_state_effect(run_ids: List[str], new_run: RunConfig):
+    def update_run_state_effect(run_ids: List[str], new_run: RunConfig, _: str):
         nonlocal first_run
         first_run = asdict(new_run)
 

--- a/src/tests/test_rest_api.py
+++ b/src/tests/test_rest_api.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from vibe_common.constants import CONTROL_STATUS_PUBSUB, WORKFLOW_REQUEST_PUBSUB_TOPIC
 from vibe_common.messaging import WorkflowCancellationMessage
-from vibe_common.statestore import StateStore
+from vibe_common.statestore import StateStore, StateStoreConflictError
 from vibe_core.data.core_types import InnerIOType
 from vibe_core.data.utils import StacConverter, deserialize_stac
 from vibe_core.datamodel import RunConfig, RunConfigInput, RunDetails, RunStatus
@@ -83,7 +83,9 @@ def test_generate_api_documentation_page(request_client: requests.Session):
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
 @patch.object(StateStore, "retrieve_bulk", side_effect=lambda _: [])
+@patch.object(StateStore, "retrieve_with_etag", side_effect=lambda _: ([], None))
 def test_workflow_submission(
+    _: MagicMock,
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
@@ -120,11 +122,98 @@ def test_workflow_submission(
     assert len(response.json()) == 1
 
 
+@patch.object(TerravibesProvider, "submit_work")
+@patch.object(
+    StateStore,
+    "transaction",
+    side_effect=[StateStoreConflictError("simulated conflict"), None],
+)
+@patch.object(
+    StateStore,
+    "retrieve_with_etag",
+    side_effect=[(["older"], "1"), (["concurrent"], "2")],
+)
+def test_workflow_submission_retries_run_index_conflict(
+    _: MagicMock,
+    transaction: MagicMock,
+    __: MagicMock,
+    workflow_run_config: Dict[str, Any],
+    request_client: requests.Session,
+):
+    response = request_client.post("/v0/runs", json=workflow_run_config)
+
+    assert response.status_code == 201
+    run_id = response.json()["id"]
+    assert transaction.await_count == 2
+    assert transaction.call_args_list[0].args[0][0]["value"] == ["older", run_id]
+    assert transaction.call_args_list[1].args[0][0]["value"] == ["concurrent", run_id]
+    assert transaction.call_args_list[1].args[0][0]["etag"] == "2"
+
+
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
 def test_no_workflow_runs(_, request_client: requests.Session):
     response = request_client.get("/v0/runs")
     assert response.status_code == 200
     assert len(response.json()) == 0
+
+
+@patch.object(StateStore, "retrieve_bulk", side_effect=KeyError("concurrent deletion"))
+@patch.object(StateStore, "retrieve")
+def test_compacted_and_missing_runs_do_not_break_bulk_listing(
+    retrieve: MagicMock,
+    _: MagicMock,
+    request_client: requests.Session,
+):
+    compacted_id = str(uuid())
+    missing_id = str(uuid())
+    compacted = asdict(
+        RunConfig(
+            name="compacted",
+            workflow="helloworld",
+            parameters={"preserved": True},
+            user_input={"input": "preserved"},
+            id=compacted_id,
+            details=RunDetails(status=RunStatus.done),
+            task_details={},
+            spatio_temporal_json=None,
+            output="",
+            history_compacted=True,
+        )
+    )
+
+    def retrieve_effect(key: str):
+        if key == compacted_id:
+            return compacted
+        raise KeyError(key)
+
+    retrieve.side_effect = retrieve_effect
+    response = request_client.get(
+        "/v0/runs",
+        params=[
+            ("ids", compacted_id),
+            ("ids", missing_id),
+            ("fields", "id"),
+            ("fields", "history_compacted"),
+            ("fields", "task_details"),
+            ("fields", "details.status"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": compacted_id,
+            "history_compacted": True,
+            "task_details": {},
+            "details.status": RunStatus.done,
+        }
+    ]
+
+    detail = request_client.get(f"/v0/runs/{compacted_id}")
+    assert detail.status_code == 200
+    assert detail.json()["history_compacted"] is True
+    assert detail.json()["task_details"] == {}
+    assert detail.json()["output"] == {}
 
 
 def test_invalid_workflow_submission(
@@ -146,7 +235,11 @@ def test_missing_field_workflow_submission(
 
 @patch.object(TerravibesProvider, "submit_work", side_effect=Exception("sorry"))
 @patch.object(TerravibesProvider, "update_run_state")
-@patch.object(TerravibesProvider, "list_runs_from_store", return_value=[])
+@patch.object(
+    TerravibesProvider,
+    "list_runs_from_store_with_etag",
+    side_effect=lambda: ([], None),
+)
 def test_submit_local_workflows_with_broken_work_submission(
     _, __: Any, ___: Any, workflow_run_config: Dict[str, Any], request_client: requests.Session
 ):
@@ -159,11 +252,13 @@ def test_submit_local_workflows_with_broken_work_submission(
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve", side_effect=lambda _: [])
 @patch.object(StateStore, "retrieve_bulk")
+@patch.object(StateStore, "retrieve_with_etag", side_effect=lambda _: ([], None))
 def test_workflow_submission_and_cancellation(
+    retrieve_with_etag: MagicMock,
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
-    _: MagicMock,
+    submit_work: MagicMock,
     send: MagicMock,
     workflow_run_config: Dict[str, Any],
     request_client: requests.Session,
@@ -189,11 +284,17 @@ def test_workflow_submission_and_cancellation(
 @pytest.mark.parametrize("params", [None, {"param1": "new_param"}])
 @patch.object(TerravibesProvider, "submit_work")
 @patch.object(TerravibesProvider, "update_run_state")
+@patch.object(
+    TerravibesProvider,
+    "list_runs_from_store_with_etag",
+    side_effect=lambda: ([], None),
+)
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk", side_effect=lambda _: [])
 def test_workflow_resubmission(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
+    _: MagicMock,
     update_run_state: MagicMock,
     submit_work: MagicMock,
     params: Optional[Dict[str, Any]],
@@ -218,6 +319,9 @@ def test_workflow_resubmission(
     response = request_client.post("/v0/runs", json=workflow_run_config)
     assert response.status_code == 201
 
+    first_run["history_compacted"] = True
+    first_run["output"] = ""
+    first_run["task_details"] = {}
     retrieve.side_effect = [first_run, []]
     response = request_client.post(f"/v0/runs/{uuid()}/resubmit")
 

--- a/src/tests/test_rest_api.py
+++ b/src/tests/test_rest_api.py
@@ -1,9 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import asyncio
+from copy import deepcopy
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4 as uuid
 
 import pytest
@@ -12,7 +14,7 @@ from fastapi.testclient import TestClient
 
 from vibe_common.constants import CONTROL_STATUS_PUBSUB, WORKFLOW_REQUEST_PUBSUB_TOPIC
 from vibe_common.messaging import WorkflowCancellationMessage
-from vibe_common.statestore import StateStore, StateStoreConflictError
+from vibe_common.statestore import DEFAULT_BULK_PARALLELISM, StateStore, StateStoreConflictError
 from vibe_core.data.core_types import InnerIOType
 from vibe_core.data.utils import StacConverter, deserialize_stac
 from vibe_core.datamodel import RunConfig, RunConfigInput, RunDetails, RunStatus
@@ -215,6 +217,66 @@ def test_compacted_and_missing_runs_do_not_break_bulk_listing(
     assert detail.json()["history_compacted"] is True
     assert detail.json()["task_details"] == {}
     assert detail.json()["output"] == {}
+
+
+@pytest.mark.anyio
+async def test_bulk_fallback_bounds_concurrency_and_skips_missing_state():
+    provider = TerravibesProvider(LocalHrefHandler("/tmp"))
+    run_ids = [str(uuid()) for _ in range(DEFAULT_BULK_PARALLELISM * 2 + 3)]
+    missing_run_id = run_ids[3]
+    missing_task_run_id = run_ids[5]
+    state: Dict[str, Any] = {}
+    for run_id in run_ids:
+        if run_id == missing_run_id:
+            continue
+        run = asdict(
+            RunConfig(
+                name=run_id,
+                workflow="helloworld",
+                parameters={},
+                user_input={},
+                id=run_id,
+                details=RunDetails(status=RunStatus.done),
+                task_details={},
+                spatio_temporal_json=None,
+            )
+        )
+        run["tasks"] = ["task"]
+        state[run_id] = run
+        if run_id != missing_task_run_id:
+            state[f"{run_id}-task"] = asdict(RunDetails(status=RunStatus.done))
+
+    active = 0
+    peak = 0
+
+    async def retrieve(key: str):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0)
+            if key not in state:
+                raise KeyError(key)
+            return deepcopy(state[key])
+        finally:
+            active -= 1
+
+    provider.state_store.retrieve_bulk = AsyncMock(side_effect=KeyError("partial bulk result"))
+    provider.state_store.retrieve = AsyncMock(side_effect=retrieve)
+
+    runs = await provider.get_bulk_runs_by_id(run_ids)
+
+    assert peak == DEFAULT_BULK_PARALLELISM
+    assert [str(run.id) for run in runs] == [
+        run_id for run_id in run_ids if run_id != missing_run_id
+    ]
+    runs_by_id = {str(run.id): run for run in runs}
+    assert runs_by_id[missing_task_run_id].task_details == {}
+    assert all(
+        run.task_details["task"].status == RunStatus.done
+        for run_id, run in runs_by_id.items()
+        if run_id != missing_task_run_id
+    )
 
 
 def test_invalid_workflow_submission(

--- a/src/tests/test_rest_api_client_integration.py
+++ b/src/tests/test_rest_api_client_integration.py
@@ -72,6 +72,11 @@ def test_empty_list_runs(_, rest_client: FarmvibesAiClient):
 @pytest.mark.parametrize("workflow", ["helloworld", j(get_workflow_dir(), "helloworld.yaml")])
 @pytest.mark.parametrize("params", [None, {}, {"param1": 1}])
 @patch.object(TerravibesProvider, "submit_work")
+@patch.object(
+    TerravibesProvider,
+    "list_runs_from_store_with_etag",
+    side_effect=lambda: ([], None),
+)
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -85,6 +90,7 @@ def test_submit_run(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,
     the_polygon: Polygon,
@@ -92,13 +98,7 @@ def test_submit_run(
     workflow: str,
     fake_ops_dir: str,
 ):
-    first_retrieve_call = True
-
     def retrieve_side_effect(_):
-        nonlocal first_retrieve_call
-        if first_retrieve_call:
-            first_retrieve_call = False
-            return []
         return asdict(transaction.call_args.args[0][1]["value"])
 
     def bulk_side_effect(_):
@@ -123,6 +123,11 @@ def test_submit_run(
 
 
 @patch.object(TerravibesProvider, "submit_work")
+@patch.object(
+    TerravibesProvider,
+    "list_runs_from_store_with_etag",
+    side_effect=lambda: ([], None),
+)
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -130,6 +135,7 @@ def test_submit_base_vibe_run(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,
 ):
@@ -140,13 +146,7 @@ def test_submit_base_vibe_run(
         seasonal_field_id=seasonal_field_id,
     )
 
-    first_retrieve_call = True
-
     def retrieve_side_effect(_):
-        nonlocal first_retrieve_call
-        if first_retrieve_call:
-            first_retrieve_call = False
-            return []
         return asdict(transaction.call_args.args[0][1]["value"])
 
     def bulk_side_effect(_):
@@ -166,6 +166,11 @@ def test_submit_base_vibe_run(
 @pytest.mark.parametrize("workflow", ["helloworld", j(get_workflow_dir(), "helloworld.yaml")])
 @pytest.mark.parametrize("params", [None, {}, {"param1": 1}])
 @patch.object(TerravibesProvider, "submit_work")
+@patch.object(
+    TerravibesProvider,
+    "list_runs_from_store_with_etag",
+    side_effect=lambda: ([], None),
+)
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -182,6 +187,7 @@ async def test_monitor_run_with_none_datetime_fields(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,
     the_polygon: Polygon,
@@ -189,7 +195,6 @@ async def test_monitor_run_with_none_datetime_fields(
     workflow: str,
     fake_ops_dir: str,
 ):
-    first_retrieve_call = True
     run_config: Optional[Dict[str, Any]] = None
 
     def store_side_effect(_: Any, obj: Any):
@@ -197,11 +202,7 @@ async def test_monitor_run_with_none_datetime_fields(
         run_config = obj
 
     def retrieve_side_effect(_):
-        nonlocal first_retrieve_call, run_config
-        if first_retrieve_call:
-            first_retrieve_call = False
-            return []
-
+        nonlocal run_config
         if run_config is None:
             run_config = asdict(transaction.call_args.args[0][1]["value"])
             if not run_config["task_details"]:

--- a/src/tests/test_rest_api_client_integration.py
+++ b/src/tests/test_rest_api_client_integration.py
@@ -129,8 +129,9 @@ def test_genuine_never_existing_run_is_not_returned_as_deleted(
 @patch.object(
     TerravibesProvider,
     "list_runs_from_store_with_etag",
-    side_effect=lambda: ([], None),
+    side_effect=[([], None), ([], "1")],
 )
+@patch.object(StateStore, "store_if_absent")
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -144,6 +145,7 @@ def test_submit_run(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    store_if_absent: MagicMock,
     list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,
@@ -180,8 +182,9 @@ def test_submit_run(
 @patch.object(
     TerravibesProvider,
     "list_runs_from_store_with_etag",
-    side_effect=lambda: ([], None),
+    side_effect=[([], None), ([], "1")],
 )
+@patch.object(StateStore, "store_if_absent")
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -189,6 +192,7 @@ def test_submit_base_vibe_run(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    store_if_absent: MagicMock,
     list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,
@@ -223,8 +227,9 @@ def test_submit_base_vibe_run(
 @patch.object(
     TerravibesProvider,
     "list_runs_from_store_with_etag",
-    side_effect=lambda: ([], None),
+    side_effect=[([], None), ([], "1")],
 )
+@patch.object(StateStore, "store_if_absent")
 @patch.object(StateStore, "transaction")
 @patch.object(StateStore, "retrieve")
 @patch.object(StateStore, "retrieve_bulk")
@@ -241,6 +246,7 @@ async def test_monitor_run_with_none_datetime_fields(
     retrieve_bulk: MagicMock,
     retrieve: MagicMock,
     transaction: MagicMock,
+    store_if_absent: MagicMock,
     list_runs: MagicMock,
     _: MagicMock,
     rest_client: FarmvibesAiClient,

--- a/src/tests/test_rest_api_client_integration.py
+++ b/src/tests/test_rest_api_client_integration.py
@@ -13,9 +13,9 @@ from fastapi.testclient import TestClient
 from shapely.geometry import Polygon
 
 from vibe_common.statestore import StateStore
-from vibe_core.client import FarmvibesAiClient
+from vibe_core.client import FarmvibesAiClient, VibeWorkflowRun
 from vibe_core.data import ADMAgSeasonalFieldInput
-from vibe_core.datamodel import RunDetails
+from vibe_core.datamodel import RunDetails, RunStatus
 from vibe_server.href_handler import LocalHrefHandler
 from vibe_server.orchestrator import WorkflowStateUpdate
 from vibe_server.server import TerravibesAPI, TerravibesProvider
@@ -67,6 +67,60 @@ async def test_list_workflows(
 def test_empty_list_runs(_, rest_client: FarmvibesAiClient):
     runs = rest_client.list_runs()
     assert not runs
+
+
+def test_delete_polling_treats_missing_after_accepted_request_as_deleted():
+    client = MagicMock(spec=FarmvibesAiClient)
+    client.delete_run.return_value = "accepted"
+    client.list_runs.return_value = []
+    run = VibeWorkflowRun("run-id", "run", "workflow", {}, client)
+
+    run.delete().block_until_deleted(0)
+
+    assert run.status == RunStatus.deleted
+    client.delete_run.assert_called_once_with("run-id")
+
+
+def test_delete_polling_handles_normal_deleting_then_deleted_status():
+    client = MagicMock(spec=FarmvibesAiClient)
+    client.delete_run.return_value = "accepted"
+    client.list_runs.side_effect = [
+        [{"details.status": RunStatus.deleting}],
+        [{"details.status": RunStatus.deleted}],
+    ]
+    run = VibeWorkflowRun("run-id", "run", "workflow", {}, client)
+    run.wait_s = 0
+
+    run.delete().block_until_deleted(1)
+
+    assert run.status == RunStatus.deleted
+    assert client.list_runs.call_count == 2
+
+
+def test_missing_run_without_accepted_delete_is_not_treated_as_deleted():
+    client = MagicMock(spec=FarmvibesAiClient)
+    client.list_runs.return_value = []
+    run = VibeWorkflowRun("missing", "run", "workflow", {}, client)
+
+    with pytest.raises(IndexError):
+        _ = run.status
+
+    client.delete_run.side_effect = RuntimeError("404 not found")
+    with pytest.raises(RuntimeError, match="404"):
+        run.delete()
+    with pytest.raises(IndexError):
+        _ = run.status
+
+
+@patch.object(StateStore, "retrieve", side_effect=KeyError("missing"))
+@patch.object(StateStore, "retrieve_bulk", side_effect=KeyError("missing"))
+def test_genuine_never_existing_run_is_not_returned_as_deleted(
+    _: MagicMock,
+    __: MagicMock,
+    rest_client: FarmvibesAiClient,
+):
+    with pytest.raises(IndexError):
+        rest_client.get_run_by_id(str(UUID(int=0)))
 
 
 @pytest.mark.parametrize("workflow", ["helloworld", j(get_workflow_dir(), "helloworld.yaml")])

--- a/src/vibe_agent/tests/test_cache_metadata_store.py
+++ b/src/vibe_agent/tests/test_cache_metadata_store.py
@@ -93,6 +93,12 @@ class AsyncFakeRedis:
     async def sismember(self, key: str, value: str):
         return value in self.data.get(key, set())
 
+    async def scan_iter(self, match: str):
+        prefix = match[:-1] if match.endswith("*") else match
+        for key in self.data:
+            if key.startswith(prefix):
+                yield key
+
     def pipeline(self, transaction: bool = True):
         return AsyncFakeRedisPipeline(self)
 
@@ -158,6 +164,22 @@ def assert_op_in_fake_redis(redis_client: AsyncFakeRedis, run_id: str, fake_op: 
         for asset_id in fake_op.asset_ids:
             asset_op_key = RedisCacheMetadataStore._asset_ops_key_format.format(asset_id=asset_id)
             assert op_ref in redis_client.data[asset_op_key]
+
+
+@pytest.mark.anyio
+async def test_find_keys():
+    do_manager, redis_client_mock, _ = get_mocked_data_ops()
+    redis_client_mock.data.update(
+        {
+            "run-id-task-a": {},
+            "run-id-task-b": {},
+            "other-key": {},
+        }
+    )
+
+    keys = await do_manager.metadata_store.find_keys("run-id-*")
+
+    assert keys == {"run-id-task-a", "run-id-task-b"}
 
 
 @pytest.mark.anyio
@@ -244,9 +266,9 @@ async def test_delete_workflow_run_no_assets(
 
     assert ss_store_mock.call_count == 2
     rc1 = ss_store_mock.call_args_list[0][0][1]
-    assert rc1.details.status == RunStatus.deleting
+    assert rc1["details"]["status"] == RunStatus.deleting
     rc2 = ss_store_mock.call_args_list[1][0][1]
-    assert rc2.details.status == RunStatus.deleted
+    assert rc2["details"]["status"] == RunStatus.deleted
 
     storage_mock.asset_manager.remove.assert_not_called()
     storage_mock.remove.assert_called_once_with(no_asset_op_run.get_op_run_id())
@@ -272,9 +294,9 @@ async def test_delete_workflow_run_simple(
 
     assert ss_store_mock.call_count == 2
     rc1 = ss_store_mock.call_args_list[0][0][1]
-    assert rc1.details.status == RunStatus.deleting
+    assert rc1["details"]["status"] == RunStatus.deleting
     rc2 = ss_store_mock.call_args_list[1][0][1]
-    assert rc2.details.status == RunStatus.deleted
+    assert rc2["details"]["status"] == RunStatus.deleted
 
     calls = [call(asset_id) for asset_id in op_1_run.asset_ids]
     storage_mock.asset_manager.remove.assert_has_calls(calls, any_order=True)

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -3,7 +3,7 @@
 
 import asyncio
 from copy import deepcopy
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock
@@ -35,7 +35,9 @@ class FakeStateStore:
         return [await self.retrieve(key) for key in keys]
 
     async def store(self, key: str, value: Any) -> None:
-        self.data[key] = asdict(value) if is_dataclass(value) else deepcopy(value)
+        self.data[key] = (
+            asdict(value) if isinstance(value, (RunConfig, RunDetails)) else deepcopy(value)
+        )
         self.versions[key] = self.versions.get(key, 0) + 1
 
     async def transaction(self, operations: List[TransactionOperation]) -> None:
@@ -56,7 +58,11 @@ class FakeStateStore:
                 updated.pop(key, None)
             else:
                 value = operation.get("value")
-                updated[key] = asdict(value) if is_dataclass(value) else deepcopy(value)
+                updated[key] = (
+                    asdict(value)
+                    if isinstance(value, (RunConfig, RunDetails))
+                    else deepcopy(value)
+                )
         self.data = updated
         for operation in operations:
             key = operation["key"]

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -18,6 +18,8 @@ from vibe_agent.data_ops import (
     DataOpsManager,
 )
 from vibe_common.constants import RUNS_KEY
+from vibe_common.dropdapr import TopicEventResponseStatus
+from vibe_common.messaging import MessageType
 from vibe_common.statestore import StateStoreConflictError, TransactionOperation
 from vibe_core.datamodel import RunConfig, RunDetails, RunStatus
 
@@ -164,15 +166,56 @@ async def test_safe_history_maintenance_remains_one_shot():
     manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
     manager.maintain_history = AsyncMock()  # type: ignore
 
-    await manager._maintain_history_safely()
+    assert await manager._maintain_history_safely()
 
     manager.maintain_history.assert_awaited_once()  # type: ignore
 
 
 @pytest.mark.anyio
+async def test_workflow_event_wakes_maintenance_without_waiting(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
+    manager.history_maintenance_task = Mock()  # type: ignore
+    manager.history_maintenance_task.done.return_value = False  # type: ignore
+    manager._maintain_history_safely = AsyncMock()  # type: ignore
+    message = Mock()
+    message.is_valid_for_channel.return_value = True
+    message.header.type = MessageType.workflow_execution_request
+
+    async def accept_event(_: Any, success: Any, __: Any):
+        return await success(message)
+
+    monkeypatch.setattr("vibe_agent.data_ops.accept_or_fail_event_async", accept_event)
+
+    response = await manager.handle_workflow_event(manager.delete_workflow_topic, Mock())
+
+    assert response == TopicEventResponseStatus.success
+    assert manager.history_maintenance_wakeup.is_set()
+    manager._maintain_history_safely.assert_not_awaited()  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_maintenance_wakeup_interrupts_periodic_delay():
+    manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
+    manager.maintain_history = AsyncMock(side_effect=[None, asyncio.CancelledError])  # type: ignore
+    task = asyncio.create_task(manager._maintain_history_periodically())
+
+    while manager.maintain_history.await_count < 1:  # type: ignore
+        await asyncio.sleep(0)
+    manager.history_maintenance_wakeup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager.maintain_history.await_count == 2  # type: ignore
+
+
+@pytest.mark.anyio
 async def test_history_maintenance_errors_back_off_and_continue(caplog: pytest.LogCaptureFixture):
     manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
-    manager.maintain_history = AsyncMock(side_effect=[RuntimeError("temporary failure"), None])  # type: ignore
+    manager.maintain_history = AsyncMock(  # type: ignore
+        side_effect=[RuntimeError("temporary failure"), RuntimeError("temporary failure")]
+    )
     sleep = AsyncMock(side_effect=[None, asyncio.CancelledError])
 
     with patch("vibe_agent.data_ops.asyncio.sleep", sleep):

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -108,6 +108,49 @@ def history_manager(
 
 
 @pytest.mark.anyio
+async def test_history_retention_is_disabled_without_both_limits():
+    run_id = str(uuid4())
+    original = run_record(run_id, RunStatus.done, ["task"])
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: original,
+            f"{run_id}-task": asdict(RunDetails(status=RunStatus.done)),
+        }
+    )
+    manager = DataOpsManager(Mock(), Mock())
+    manager.statestore = state  # type: ignore
+    manager._init_locks()
+
+    await manager.maintain_history()
+
+    assert state.data[RUNS_KEY] == [run_id]
+    assert state.data[run_id] == original
+    assert f"{run_id}-task" in state.data
+
+    with pytest.raises(ValueError, match="configured together"):
+        DataOpsManager(Mock(), Mock(), max_full_history_runs=1)
+
+
+def test_history_retention_defaults_are_local_only(monkeypatch: pytest.MonkeyPatch):
+    for name in (
+        "STAC_COSMOS_URI_SECRET",
+        "STAC_COSMOS_CONNECTION_KEY_SECRET",
+        "STAC_COSMOS_DATABASE_NAME_SECRET",
+        "STAC_CONTAINER_NAME_SECRET",
+        "BLOB_CONTAINER_NAME",
+    ):
+        monkeypatch.setenv(name, "test")
+
+    from vibe_agent.launch_data_ops import aks_data_ops_config, local_data_ops_config
+
+    assert local_data_ops_config.max_full_history_runs == 100
+    assert local_data_ops_config.max_compact_history_runs == 900
+    assert aks_data_ops_config.max_full_history_runs is None
+    assert aks_data_ops_config.max_compact_history_runs is None
+
+
+@pytest.mark.anyio
 async def test_history_tiers_compact_delete_and_preserve_active_runs():
     run_ids = [str(uuid4()) for _ in range(6)]
     statuses = [

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -151,6 +151,24 @@ def test_history_retention_defaults_are_local_only(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.anyio
+async def test_zero_limits_hard_delete_terminal_history():
+    run_id = str(uuid4())
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: run_record(run_id, RunStatus.done, ["task"]),
+            f"{run_id}-task": asdict(RunDetails(status=RunStatus.done)),
+        }
+    )
+
+    await history_manager(state, max_full=0, max_compact=0).maintain_history()
+
+    assert state.data[RUNS_KEY] == []
+    assert run_id not in state.data
+    assert f"{run_id}-task" not in state.data
+
+
+@pytest.mark.anyio
 async def test_history_tiers_compact_delete_and_preserve_active_runs():
     run_ids = [str(uuid4()) for _ in range(6)]
     statuses = [

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -170,6 +170,18 @@ def test_history_retention_defaults_are_local_only(monkeypatch: pytest.MonkeyPat
     assert aks_data_ops_config.max_compact_history_runs is None
 
 
+def test_history_limits_can_be_configured_without_cli_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vibe_agent.launch_data_ops import history_limit
+
+    monkeypatch.setenv("MAX_FULL_HISTORY_RUNS", "12")
+    monkeypatch.setenv("MAX_COMPACT_HISTORY_RUNS", "34")
+
+    assert history_limit("MAX_FULL_HISTORY_RUNS", 100) == 12
+    assert history_limit("MAX_COMPACT_HISTORY_RUNS", 900) == 34
+
+
 @pytest.mark.anyio
 async def test_zero_limits_hard_delete_terminal_history():
     run_id = str(uuid4())

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -76,7 +76,7 @@ def run_record(run_id: str, status: RunStatus, tasks: List[str]) -> Dict[str, An
             workflow="helloworld",
             parameters={"keep": True},
             user_input={"input": "preserved"},
-            id=run_id,
+            id=UUID(run_id),
             details=RunDetails(
                 submission_time=datetime.now(),
                 end_time=datetime.now() if status != RunStatus.running else None,

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -114,6 +114,20 @@ def history_manager(
 
 
 @pytest.mark.anyio
+async def test_startup_defers_history_maintenance_until_app_is_ready():
+    manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
+    manager._maintain_history_safely = AsyncMock()  # type: ignore
+    startup = manager.app.app.router.on_startup[0]
+
+    assert startup() is None
+    manager._maintain_history_safely.assert_not_awaited()  # type: ignore
+
+    await asyncio.sleep(0)
+
+    manager._maintain_history_safely.assert_awaited_once()  # type: ignore
+
+
+@pytest.mark.anyio
 async def test_history_retention_is_disabled_without_both_limits():
     run_id = str(uuid4())
     original = run_record(run_id, RunStatus.done, ["task"])

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -1,0 +1,268 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import asyncio
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from vibe_agent.data_ops import WORKFLOW_TASK_KEY_PATTERN, DataOpsManager
+from vibe_common.constants import RUNS_KEY
+from vibe_common.statestore import StateStoreConflictError, TransactionOperation
+from vibe_core.datamodel import RunConfig, RunDetails, RunStatus
+
+
+class FakeStateStore:
+    def __init__(self, data: Dict[str, Any]):
+        self.data = deepcopy(data)
+        self.versions = {key: 1 for key in data}
+        self.conflicts_remaining = 0
+
+    async def retrieve(self, key: str) -> Any:
+        if key not in self.data:
+            raise KeyError(key)
+        return deepcopy(self.data[key])
+
+    async def retrieve_with_etag(self, key: str):
+        return await self.retrieve(key), str(self.versions[key])
+
+    async def retrieve_bulk(self, keys: List[str]) -> List[Any]:
+        return [await self.retrieve(key) for key in keys]
+
+    async def store(self, key: str, value: Any) -> None:
+        self.data[key] = asdict(value) if is_dataclass(value) else deepcopy(value)
+        self.versions[key] = self.versions.get(key, 0) + 1
+
+    async def transaction(self, operations: List[TransactionOperation]) -> None:
+        for operation in operations:
+            if "etag" not in operation:
+                continue
+            if self.conflicts_remaining:
+                self.conflicts_remaining -= 1
+                self.versions[operation["key"]] += 1
+                raise StateStoreConflictError("simulated conflict")
+            if operation["etag"] != str(self.versions[operation["key"]]):
+                raise StateStoreConflictError("etag mismatch")
+
+        updated = deepcopy(self.data)
+        for operation in operations:
+            key = operation["key"]
+            if operation["operation"] == "delete":
+                updated.pop(key, None)
+            else:
+                value = operation.get("value")
+                updated[key] = asdict(value) if is_dataclass(value) else deepcopy(value)
+        self.data = updated
+        for operation in operations:
+            key = operation["key"]
+            self.versions[key] = self.versions.get(key, 0) + 1
+
+
+def run_record(run_id: str, status: RunStatus, tasks: List[str]) -> Dict[str, Any]:
+    record = asdict(
+        RunConfig(
+            name=f"run-{run_id}",
+            workflow="helloworld",
+            parameters={"keep": True},
+            user_input={"input": "preserved"},
+            id=run_id,
+            details=RunDetails(
+                submission_time=datetime.now(),
+                end_time=datetime.now() if status != RunStatus.running else None,
+                status=status,
+            ),
+            task_details={},
+            spatio_temporal_json=None,
+            output="large-encoded-output",
+        )
+    )
+    record["tasks"] = tasks
+    return record
+
+
+def history_manager(
+    state: FakeStateStore,
+    max_full: int,
+    max_compact: int,
+    scan_redis_workflow_state: bool = False,
+) -> DataOpsManager:
+    metadata_store = Mock()
+    metadata_store.get_run_ops = AsyncMock(return_value=set())
+    metadata_store.find_keys = AsyncMock(return_value=set())
+    storage = Mock()
+    manager = DataOpsManager(
+        storage,
+        metadata_store,
+        max_full_history_runs=max_full,
+        max_compact_history_runs=max_compact,
+        scan_redis_workflow_state=scan_redis_workflow_state,
+    )
+    manager.statestore = state  # type: ignore
+    manager._init_locks()
+    return manager
+
+
+@pytest.mark.anyio
+async def test_history_tiers_compact_delete_and_preserve_active_runs():
+    run_ids = [str(uuid4()) for _ in range(6)]
+    statuses = [
+        RunStatus.done,
+        RunStatus.running,
+        RunStatus.done,
+        RunStatus.deleted,
+        RunStatus.done,
+        RunStatus.running,
+    ]
+    state_data: Dict[str, Any] = {RUNS_KEY: run_ids}
+    for run_id, status in zip(run_ids, statuses):
+        state_data[run_id] = run_record(run_id, status, ["task"])
+        state_data[f"{run_id}-task"] = asdict(RunDetails(status=status))
+
+    state = FakeStateStore(state_data)
+    manager = history_manager(state, max_full=2, max_compact=2)
+
+    await manager.maintain_history()
+
+    deleted, active, compacted, compacted_deleted, full, newest_active = run_ids
+    assert deleted not in state.data
+    assert f"{deleted}-task" not in state.data
+    assert state.data[RUNS_KEY] == run_ids[1:]
+    manager.metadata_store.get_run_ops.assert_awaited_once_with(deleted)  # type: ignore
+
+    assert state.data[active] == state_data[active]
+    assert state.data[f"{active}-task"] == state_data[f"{active}-task"]
+
+    for run_id in (compacted, compacted_deleted):
+        summary = state.data[run_id]
+        assert summary["history_compacted"] is True
+        assert summary["task_details"] == {}
+        assert summary["output"] == ""
+        assert summary["workflow"] == "helloworld"
+        assert summary["parameters"] == {"keep": True}
+        assert summary["user_input"] == {"input": "preserved"}
+        assert f"{run_id}-task" not in state.data
+
+    for run_id in (full, newest_active):
+        assert state.data[run_id] == state_data[run_id]
+        assert state.data[f"{run_id}-task"] == state_data[f"{run_id}-task"]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [RunStatus.pending, RunStatus.queued, RunStatus.running, RunStatus.deleting],
+)
+@pytest.mark.parametrize("max_compact", [0, 1])
+@pytest.mark.anyio
+async def test_nonterminal_runs_are_never_touched(status: RunStatus, max_compact: int):
+    run_id = str(uuid4())
+    original = run_record(run_id, status, ["task"])
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: original,
+            f"{run_id}-task": asdict(RunDetails(status=status)),
+        }
+    )
+    manager = history_manager(
+        state,
+        max_full=0,
+        max_compact=max_compact,
+        scan_redis_workflow_state=True,
+    )
+
+    await manager.maintain_history()
+
+    assert state.data[RUNS_KEY] == [run_id]
+    assert state.data[run_id] == original
+    assert f"{run_id}-task" in state.data
+    manager.metadata_store.get_run_ops.assert_not_awaited()  # type: ignore
+    manager.metadata_store.find_keys.assert_not_awaited()  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_repeated_concurrent_maintenance_is_idempotent_after_index_conflict():
+    run_id = str(uuid4())
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: run_record(run_id, RunStatus.done, ["task"]),
+            f"{run_id}-task": asdict(RunDetails(status=RunStatus.done)),
+        }
+    )
+    state.conflicts_remaining = 1
+    manager = history_manager(state, max_full=0, max_compact=0)
+
+    await asyncio.gather(manager.maintain_history(), manager.maintain_history())
+    await manager.maintain_history()
+
+    assert state.data[RUNS_KEY] == []
+    assert run_id not in state.data
+    assert f"{run_id}-task" not in state.data
+    manager.metadata_store.get_run_ops.assert_awaited_once_with(run_id)  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_interrupted_retention_cleanup_resumes_before_hard_delete():
+    run_id = str(uuid4())
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: run_record(run_id, RunStatus.done, ["task"]),
+            f"{run_id}-task": asdict(RunDetails(status=RunStatus.done)),
+        }
+    )
+    manager = history_manager(state, max_full=0, max_compact=0)
+    manager.metadata_store.get_run_ops.side_effect = [  # type: ignore
+        RuntimeError("temporary metadata failure"),
+        set(),
+    ]
+
+    await manager.maintain_history()
+
+    interrupted = RunConfig(**state.data[run_id])
+    assert interrupted.details.status == RunStatus.deleting
+    assert interrupted.details.reason == manager.retention_deletion_reason
+    assert state.data[run_id]["tasks"] == ["task"]
+    assert run_id in state.data[RUNS_KEY]
+    assert f"{run_id}-task" in state.data
+
+    await manager.maintain_history()
+
+    assert state.data[RUNS_KEY] == []
+    assert run_id not in state.data
+    assert f"{run_id}-task" not in state.data
+    assert manager.metadata_store.get_run_ops.await_count == 2  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_legacy_task_keys_are_discovered_for_local_redis_compaction():
+    run_id = str(uuid4())
+    record = run_record(run_id, RunStatus.done, ["task"])
+    del record["tasks"]
+    state = FakeStateStore(
+        {
+            RUNS_KEY: [run_id],
+            run_id: record,
+            f"{run_id}-task": asdict(RunDetails(status=RunStatus.done)),
+        }
+    )
+    manager = history_manager(
+        state,
+        max_full=0,
+        max_compact=1,
+        scan_redis_workflow_state=True,
+    )
+    manager.metadata_store.find_keys.return_value = {f"{run_id}-task"}  # type: ignore
+
+    await manager.maintain_history()
+
+    assert state.data[run_id]["history_compacted"] is True
+    assert f"{run_id}-task" not in state.data
+    manager.metadata_store.find_keys.assert_awaited_once_with(  # type: ignore
+        WORKFLOW_TASK_KEY_PATTERN
+    )

--- a/src/vibe_agent/tests/test_run_history.py
+++ b/src/vibe_agent/tests/test_run_history.py
@@ -6,12 +6,17 @@ from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Dict, List
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call, patch
 from uuid import UUID, uuid4
 
 import pytest
 
-from vibe_agent.data_ops import WORKFLOW_TASK_KEY_PATTERN, DataOpsManager
+from vibe_agent.data_ops import (
+    HISTORY_MAINTENANCE_BATCH_SIZE,
+    HISTORY_MAINTENANCE_INTERVAL_S,
+    WORKFLOW_TASK_KEY_PATTERN,
+    DataOpsManager,
+)
 from vibe_common.constants import RUNS_KEY
 from vibe_common.statestore import StateStoreConflictError, TransactionOperation
 from vibe_core.datamodel import RunConfig, RunDetails, RunStatus
@@ -116,15 +121,103 @@ def history_manager(
 @pytest.mark.anyio
 async def test_startup_defers_history_maintenance_until_app_is_ready():
     manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
-    manager._maintain_history_safely = AsyncMock()  # type: ignore
+    started = asyncio.Event()
+
+    async def wait_for_shutdown():
+        started.set()
+        await asyncio.Event().wait()
+
+    manager._maintain_history_periodically = AsyncMock(side_effect=wait_for_shutdown)  # type: ignore
     startup = manager.app.app.router.on_startup[0]
+    shutdown = manager.app.app.router.on_shutdown[0]
 
     assert startup() is None
-    manager._maintain_history_safely.assert_not_awaited()  # type: ignore
+    task = manager.history_maintenance_task
+    assert task is not None
+    try:
+        assert not started.is_set()
+        assert startup() is None
+        assert manager.history_maintenance_task is task
+        await asyncio.wait_for(started.wait(), 1)
+        manager._maintain_history_periodically.assert_awaited_once()  # type: ignore
+    finally:
+        await shutdown()
 
+    assert task.cancelled()
+    assert manager.history_maintenance_task is None
+
+
+@pytest.mark.anyio
+async def test_disabled_history_retention_starts_no_maintenance_task():
+    manager = DataOpsManager(Mock(), Mock())
+    manager._maintain_history_periodically = AsyncMock()  # type: ignore
+
+    manager.app.app.router.on_startup[0]()
     await asyncio.sleep(0)
 
-    manager._maintain_history_safely.assert_awaited_once()  # type: ignore
+    assert manager.history_maintenance_task is None
+    manager._maintain_history_periodically.assert_not_awaited()  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_safe_history_maintenance_remains_one_shot():
+    manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
+    manager.maintain_history = AsyncMock()  # type: ignore
+
+    await manager._maintain_history_safely()
+
+    manager.maintain_history.assert_awaited_once()  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_history_maintenance_errors_back_off_and_continue(caplog: pytest.LogCaptureFixture):
+    manager = history_manager(FakeStateStore({RUNS_KEY: []}), 100, 900)
+    manager.maintain_history = AsyncMock(side_effect=[RuntimeError("temporary failure"), None])  # type: ignore
+    sleep = AsyncMock(side_effect=[None, asyncio.CancelledError])
+
+    with patch("vibe_agent.data_ops.asyncio.sleep", sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await manager._maintain_history_periodically()
+
+    assert manager.maintain_history.await_count == 2  # type: ignore
+    assert sleep.await_args_list == [
+        call(HISTORY_MAINTENANCE_INTERVAL_S),
+        call(HISTORY_MAINTENANCE_INTERVAL_S),
+    ]
+    assert "Failed to maintain workflow run history" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_periodic_maintenance_revisits_active_run_after_it_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    run_id = str(uuid4())
+    state = FakeStateStore({RUNS_KEY: [run_id], run_id: run_record(run_id, RunStatus.running, [])})
+    manager = history_manager(state, max_full=0, max_compact=0)
+    delete_history_run = AsyncMock(wraps=manager._delete_history_run)
+    manager._delete_history_run = delete_history_run  # type: ignore
+    monkeypatch.setattr("vibe_agent.data_ops.HISTORY_MAINTENANCE_INTERVAL_S", 0.001)
+    startup = manager.app.app.router.on_startup[0]
+    shutdown = manager.app.app.router.on_shutdown[0]
+
+    startup()
+    try:
+        for _ in range(100):
+            if delete_history_run.await_count:
+                break
+            await asyncio.sleep(0.001)
+        assert delete_history_run.await_count
+        assert run_id in state.data
+
+        state.data[run_id] = run_record(run_id, RunStatus.done, [])
+        for _ in range(100):
+            if run_id not in state.data:
+                break
+            await asyncio.sleep(0.001)
+        assert run_id not in state.data
+        assert state.data[RUNS_KEY] == []
+    finally:
+        await shutdown()
 
 
 @pytest.mark.anyio
@@ -198,6 +291,30 @@ async def test_zero_limits_hard_delete_terminal_history():
     assert state.data[RUNS_KEY] == []
     assert run_id not in state.data
     assert f"{run_id}-task" not in state.data
+
+
+@pytest.mark.anyio
+async def test_large_history_backlog_converges_across_bounded_passes():
+    run_ids = [str(uuid4()) for _ in range(2001)]
+    state = FakeStateStore({RUNS_KEY: run_ids})
+    manager = history_manager(state, max_full=0, max_compact=0)
+
+    async def delete_run(run_id: str) -> bool:
+        state.data[RUNS_KEY].remove(run_id)
+        return True
+
+    manager._delete_history_run = AsyncMock(side_effect=delete_run)  # type: ignore
+    for _ in range(len(run_ids)):
+        before = len(state.data[RUNS_KEY])
+        await manager.maintain_history()
+        removed = before - len(state.data[RUNS_KEY])
+        assert 0 < removed <= HISTORY_MAINTENANCE_BATCH_SIZE
+        if not state.data[RUNS_KEY]:
+            break
+    else:
+        pytest.fail("history backlog did not converge")
+
+    assert manager._delete_history_run.await_count == len(run_ids)  # type: ignore
 
 
 @pytest.mark.anyio

--- a/src/vibe_agent/vibe_agent/cache_metadata_store.py
+++ b/src/vibe_agent/vibe_agent/cache_metadata_store.py
@@ -30,6 +30,8 @@ class CacheMetadataStoreProtocol(Protocol):
 
     async def get_assets_refs(self, asset_ids: Set[str]) -> Dict[str, Set[OpRunId]]: ...
 
+    async def find_keys(self, pattern: str) -> Set[str]: ...
+
     async def remove_workflow_op_refs(
         self, workflow_run_id: str, op_run_ref: OpRunId
     ) -> Set[str]: ...
@@ -130,6 +132,14 @@ class RedisCacheMetadataStore(CacheMetadataStoreProtocol):
             run_ops_key = self._run_ops_key_format.format(run_id=run_id)
             run_ops = await redis_client.smembers(run_ops_key)
             return {self._str_to_op_run_id(o) for o in run_ops}
+        finally:
+            await redis_client.close()
+
+    async def find_keys(self, pattern: str) -> Set[str]:
+        """Find raw Redis keys for legacy workflow state cleanup."""
+        redis_client = await self._get_redis_client()
+        try:
+            return {key async for key in redis_client.scan_iter(match=pattern)}
         finally:
             await redis_client.close()
 

--- a/src/vibe_agent/vibe_agent/data_ops.py
+++ b/src/vibe_agent/vibe_agent/data_ops.py
@@ -135,13 +135,17 @@ class DataOpsManager:
         self.history_maintenance_lock = asyncio.Lock()
         self.history_compaction_offset = 0
         self.history_deletion_offset = 0
+        self.history_maintenance_task: Optional[asyncio.Task[None]] = None
 
     def _setup_routes(self):
         @self.app.startup()
-        async def startup():
+        def startup():
             # locks have to be be created on the app's (uvicorn's) event loop
             self._init_locks()
-            await self._maintain_history_safely()
+            # Dapr is not available until the app startup hook returns.
+            self.history_maintenance_task = asyncio.create_task(
+                self._maintain_history_safely()
+            )
 
         @self.app.subscribe_async(self.pubsubname, self.status_topic)
         async def fetch_work(event: v1.Event) -> TopicEventResponse:

--- a/src/vibe_agent/vibe_agent/data_ops.py
+++ b/src/vibe_agent/vibe_agent/data_ops.py
@@ -95,11 +95,17 @@ class DataOpsManager:
         log_backup_count: int = LOG_BACKUP_COUNT,
         loglevel: Optional[str] = None,
         otel_service_name: str = "",
-        max_full_history_runs: int = DEFAULT_MAX_FULL_HISTORY_RUNS,
-        max_compact_history_runs: int = DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+        max_full_history_runs: Optional[int] = None,
+        max_compact_history_runs: Optional[int] = None,
         scan_redis_workflow_state: bool = False,
     ):
-        if max_full_history_runs < 0 or max_compact_history_runs < 0:
+        if (max_full_history_runs is None) != (max_compact_history_runs is None):
+            raise ValueError("Both workflow history limits must be configured together")
+        if (
+            max_full_history_runs is not None
+            and max_compact_history_runs is not None
+            and (max_full_history_runs < 0 or max_compact_history_runs < 0)
+        ):
             raise ValueError("Workflow history limits must be non-negative")
 
         self.app = App()
@@ -317,6 +323,9 @@ class DataOpsManager:
 
     async def maintain_history(self) -> None:
         """Compact and delete a bounded slice of old workflow history."""
+        if self.max_full_history_runs is None or self.max_compact_history_runs is None:
+            return
+
         async with self.history_maintenance_lock:  # type: ignore
             try:
                 run_ids: List[str] = await self.statestore.retrieve(RUNS_KEY)
@@ -576,8 +585,8 @@ DataOpsConfig = builds(
     max_log_file_bytes=MAX_LOG_FILE_BYTES,
     log_backup_count=LOG_BACKUP_COUNT,
     loglevel=None,
-    max_full_history_runs=DEFAULT_MAX_FULL_HISTORY_RUNS,
-    max_compact_history_runs=DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+    max_full_history_runs=None,
+    max_compact_history_runs=None,
     scan_redis_workflow_state=False,
     otel_service_name="",
 )

--- a/src/vibe_agent/vibe_agent/data_ops.py
+++ b/src/vibe_agent/vibe_agent/data_ops.py
@@ -3,7 +3,9 @@
 
 import asyncio
 import logging
-from typing import List, Optional, Set, cast
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Set, cast
+from uuid import UUID
 
 from aiorwlock import RWLock
 from cloudevents.sdk.event import v1
@@ -19,6 +21,7 @@ from vibe_agent.cache_metadata_store import (
 from vibe_agent.storage.storage import Storage, StorageConfig
 from vibe_common.constants import (
     CONTROL_STATUS_PUBSUB,
+    RUNS_KEY,
     STATUS_PUBSUB_TOPIC,
     TRACEPARENT_HEADER_KEY,
     WORKFLOW_REQUEST_PUBSUB_TOPIC,
@@ -34,12 +37,19 @@ from vibe_common.messaging import (
     run_id_from_traceparent,
 )
 from vibe_common.schemas import OpRunId, OpRunIdDict
-from vibe_common.statestore import StateStore
+from vibe_common.statestore import StateStore, StateStoreConflictError, TransactionOperation
 from vibe_common.telemetry import add_trace, setup_telemetry, update_telemetry_context
 from vibe_core.data.core_types import OpIOType
 from vibe_core.datamodel import RunConfig, RunStatus
 from vibe_core.logconfig import LOG_BACKUP_COUNT, MAX_LOG_FILE_BYTES, configure_logging
 from vibe_core.utils import ensure_list
+
+DEFAULT_MAX_FULL_HISTORY_RUNS = 100
+DEFAULT_MAX_COMPACT_HISTORY_RUNS = 900
+HISTORY_MAINTENANCE_BATCH_SIZE = 10
+HISTORY_MAINTENANCE_SCAN_SIZE = 100
+HISTORY_INDEX_UPDATE_RETRIES = 3
+WORKFLOW_TASK_KEY_PATTERN = "????????-????-????-????-????????????-*"
 
 
 class DataOpsManager:
@@ -64,8 +74,13 @@ class DataOpsManager:
     metadata_store_lock: RWLock
     otel_service_name: str
     statestore_lock: asyncio.Lock
+    history_maintenance_lock: asyncio.Lock
+    history_compaction_offset: int
+    history_deletion_offset: int
+    legacy_task_keys: Optional[Dict[str, List[str]]]
 
     user_deletion_reason = "Deletion requested by user"
+    retention_deletion_reason = "Deletion requested by workflow history retention"
 
     def __init__(
         self,
@@ -80,7 +95,13 @@ class DataOpsManager:
         log_backup_count: int = LOG_BACKUP_COUNT,
         loglevel: Optional[str] = None,
         otel_service_name: str = "",
+        max_full_history_runs: int = DEFAULT_MAX_FULL_HISTORY_RUNS,
+        max_compact_history_runs: int = DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+        scan_redis_workflow_state: bool = False,
     ):
+        if max_full_history_runs < 0 or max_compact_history_runs < 0:
+            raise ValueError("Workflow history limits must be non-negative")
+
         self.app = App()
         self.port = port
         self.pubsubname = pubsubname
@@ -94,6 +115,10 @@ class DataOpsManager:
         self.log_backup_count = log_backup_count
         self.loglevel = loglevel
         self.otel_service_name = otel_service_name
+        self.max_full_history_runs = max_full_history_runs
+        self.max_compact_history_runs = max_compact_history_runs
+        self.scan_redis_workflow_state = scan_redis_workflow_state
+        self.legacy_task_keys = None
 
         self._setup_routes()
 
@@ -101,12 +126,16 @@ class DataOpsManager:
         logging.debug("Creating locks")
         self.metadata_store_lock = RWLock(fast=True)
         self.statestore_lock = asyncio.Lock()
+        self.history_maintenance_lock = asyncio.Lock()
+        self.history_compaction_offset = 0
+        self.history_deletion_offset = 0
 
     def _setup_routes(self):
         @self.app.startup()
-        def startup():
+        async def startup():
             # locks have to be be created on the app's (uvicorn's) event loop
             self._init_locks()
+            await self._maintain_history_safely()
 
         @self.app.subscribe_async(self.pubsubname, self.status_topic)
         async def fetch_work(event: v1.Event) -> TopicEventResponse:
@@ -184,6 +213,12 @@ class DataOpsManager:
                 run_id = str(message.run_id)
                 await self.delete_workflow_run(run_id)
 
+            if message.header.type in {
+                MessageType.workflow_execution_request,
+                MessageType.workflow_deletion_request,
+            }:
+                await self._maintain_history_safely()
+
             return TopicEventResponseStatus.success
 
         async def failure_callback(
@@ -248,7 +283,7 @@ class DataOpsManager:
 
         return can_delete
 
-    async def _init_delete(self, run_id: str) -> bool:
+    async def _init_delete(self, run_id: str, deletion_reason: str = user_deletion_reason) -> bool:
         async with self.statestore_lock:  # type: ignore
             # Using an async lock to ensure two deletion requests for the same workflow run don't
             # get processed at the same time.
@@ -256,24 +291,201 @@ class DataOpsManager:
             # The assumption is once the workflow is finished, the RunConfig will not change in the
             # statestore (i.e. the status will not change) outside of the Data Ops Manager so it is
             # sufficient to use asyncio lock in the Data Ops manager.
-            run_data = await self.statestore.retrieve(str(run_id))
+            run_data = deepcopy(await self.statestore.retrieve(str(run_id)))
             run_config = RunConfig(**run_data)
 
             if not self._can_delete(run_config):
                 return False
 
-            run_config.details.status = RunStatus.deleting
-            run_config.details.reason = self.user_deletion_reason
-            await self.statestore.store(run_id, run_config)
+            run_data["details"]["status"] = RunStatus.deleting
+            run_data["details"]["reason"] = deletion_reason
+            await self.statestore.store(run_id, run_data)
             return True
 
     async def _finalize_delete(self, run_id: str) -> None:
         async with self.statestore_lock:  # type: ignore
-            run_data = await self.statestore.retrieve(str(run_id))
+            run_data = deepcopy(await self.statestore.retrieve(str(run_id)))
+            run_data["details"]["status"] = RunStatus.deleted
+            run_data["output"] = ""
+            await self.statestore.store(run_id, run_data)
+
+    async def _maintain_history_safely(self) -> None:
+        try:
+            await self.maintain_history()
+        except Exception:
+            logging.exception("Failed to maintain workflow run history")
+
+    async def maintain_history(self) -> None:
+        """Compact and delete a bounded slice of old workflow history."""
+        async with self.history_maintenance_lock:  # type: ignore
+            try:
+                run_ids: List[str] = await self.statestore.retrieve(RUNS_KEY)
+            except KeyError:
+                return
+
+            full_history_start = max(0, len(run_ids) - self.max_full_history_runs)
+            compact_history_start = max(0, full_history_start - self.max_compact_history_runs)
+            deletion_candidates = run_ids[:compact_history_start]
+            compaction_candidates = run_ids[compact_history_start:full_history_start]
+
+            deletion_scan: List[str] = []
+            if deletion_candidates:
+                start = self.history_deletion_offset % len(deletion_candidates)
+                ordered_candidates = deletion_candidates[start:] + deletion_candidates[:start]
+                deletion_scan = ordered_candidates[:HISTORY_MAINTENANCE_SCAN_SIZE]
+                self.history_deletion_offset = (start + len(deletion_scan)) % len(
+                    deletion_candidates
+                )
+
+            deleted = 0
+            for run_id in deletion_scan:
+                if deleted >= HISTORY_MAINTENANCE_BATCH_SIZE:
+                    break
+                try:
+                    if await self._delete_history_run(run_id):
+                        deleted += 1
+                except Exception:
+                    logging.exception(f"Failed to delete retained workflow run {run_id}")
+
+            compaction_scan: List[str] = []
+            if compaction_candidates:
+                offset = self.history_compaction_offset % len(compaction_candidates)
+                end = len(compaction_candidates) - offset
+                start = max(0, end - HISTORY_MAINTENANCE_SCAN_SIZE)
+                compaction_scan = compaction_candidates[start:end]
+                self.history_compaction_offset = (offset + len(compaction_scan)) % len(
+                    compaction_candidates
+                )
+
+            compacted = 0
+            for run_id in reversed(compaction_scan):
+                if compacted >= HISTORY_MAINTENANCE_BATCH_SIZE:
+                    break
+                try:
+                    if await self._compact_history_run(run_id):
+                        compacted += 1
+                except Exception:
+                    logging.exception(f"Failed to compact workflow run {run_id}")
+
+    async def _compact_history_run(self, run_id: str) -> bool:
+        async with self.statestore_lock:  # type: ignore
+            try:
+                run_data = await self.statestore.retrieve(run_id)
+            except KeyError:
+                return False
+
             run_config = RunConfig(**run_data)
-            run_config.details.status = RunStatus.deleted
-            run_config.set_output({})
-            await self.statestore.store(run_id, run_config)
+            status = run_config.details.status
+            if not (RunStatus.finished(status) or status == RunStatus.deleted):
+                return False
+            if run_config.history_compacted:
+                return False
+
+            task_keys = await self._get_task_state_keys(run_id, run_data)
+            run_config.task_details = {}
+            run_config.output = ""
+            run_config.history_compacted = True
+            operations = [TransactionOperation(key=key, operation="delete") for key in task_keys]
+            operations.append(
+                TransactionOperation(key=run_id, operation="upsert", value=run_config)
+            )
+            await self.statestore.transaction(operations)
+            if self.legacy_task_keys is not None:
+                self.legacy_task_keys.pop(run_id, None)
+            logging.info(f"Compacted workflow run history for {run_id}")
+            return True
+
+    async def _delete_history_run(self, run_id: str) -> bool:
+        try:
+            run_data = await self.statestore.retrieve(run_id)
+        except KeyError:
+            return await self._remove_history_entry(run_id, [])
+
+        run_config = RunConfig(**run_data)
+        status = run_config.details.status
+        retention_deleting = (
+            status == RunStatus.deleting
+            and run_config.details.reason == self.retention_deletion_reason
+        )
+        if not (status == RunStatus.deleted or retention_deleting or RunStatus.finished(status)):
+            return False
+
+        task_keys = await self._get_task_state_keys(run_id, run_data)
+        if status == RunStatus.deleted:
+            cleanup_complete = True
+        elif retention_deleting:
+            cleanup_complete = await self._finish_delete_workflow_run(run_id)
+        else:
+            cleanup_complete = await self.delete_workflow_run(
+                run_id, self.retention_deletion_reason
+            )
+
+        if not cleanup_complete:
+            return False
+
+        state_keys = [run_id] + task_keys
+        await self._remove_history_entry(run_id, state_keys)
+        if self.legacy_task_keys is not None:
+            self.legacy_task_keys.pop(run_id, None)
+        logging.info(f"Deleted workflow run history for {run_id}")
+        return True
+
+    async def _remove_history_entry(self, run_id: str, state_keys: List[str]) -> bool:
+        for attempt in range(HISTORY_INDEX_UPDATE_RETRIES):
+            try:
+                run_ids, etag = await self.statestore.retrieve_with_etag(RUNS_KEY)
+            except KeyError:
+                if state_keys:
+                    await self.statestore.transaction(
+                        [TransactionOperation(key=key, operation="delete") for key in state_keys]
+                    )
+                return bool(state_keys)
+
+            if etag is None:
+                raise RuntimeError("State store did not return an ETag for the workflow run index")
+
+            indexed = run_id in run_ids
+            updated_run_ids = [candidate for candidate in run_ids if candidate != run_id]
+            operations = [TransactionOperation(key=key, operation="delete") for key in state_keys]
+            operations.append(
+                TransactionOperation(
+                    key=RUNS_KEY,
+                    operation="upsert",
+                    value=updated_run_ids,
+                    etag=etag,
+                    options={"concurrency": "first-write", "consistency": "strong"},
+                )
+            )
+            try:
+                await self.statestore.transaction(operations)
+                return indexed or bool(state_keys)
+            except StateStoreConflictError:
+                if attempt + 1 == HISTORY_INDEX_UPDATE_RETRIES:
+                    raise
+        return False
+
+    async def _get_task_state_keys(self, run_id: str, run_data: Dict[str, Any]) -> List[str]:
+        task_keys = [f"{run_id}-{task}" for task in run_data.get("tasks", [])]
+        if task_keys or not self.scan_redis_workflow_state:
+            return task_keys
+
+        if self.legacy_task_keys is None:
+            legacy_task_keys: Dict[str, List[str]] = {}
+            for key in await self.metadata_store.find_keys(WORKFLOW_TASK_KEY_PATTERN):
+                candidate_run_id = key[:36]
+                try:
+                    UUID(candidate_run_id)
+                except ValueError:
+                    continue
+                legacy_task_keys.setdefault(candidate_run_id, []).append(key)
+            self.legacy_task_keys = legacy_task_keys
+
+        task_keys = sorted(self.legacy_task_keys.get(run_id, []))
+        if task_keys:
+            logging.info(
+                f"Found {len(task_keys)} legacy task state key(s) for workflow run {run_id}"
+            )
+        return task_keys
 
     async def delete_op_run(self, op_run: OpRunId) -> None:
         # TODO: the following two calls may be able to be combined into one call to a Lua script
@@ -301,10 +513,8 @@ class DataOpsManager:
         self.storage.remove(op_run)
         await self.metadata_store.remove_op_asset_refs(op_run, op_asset_ids)
 
-    async def delete_workflow_run(self, run_id: str) -> bool:
-        if not await self._init_delete(run_id):
-            return False
-
+    async def _finish_delete_workflow_run(self, run_id: str) -> bool:
+        """Finish idempotent cleanup after a run has entered deleting state."""
         op_runs = await self.metadata_store.get_run_ops(run_id)
 
         for op_run in op_runs:
@@ -324,6 +534,14 @@ class DataOpsManager:
 
         await self._finalize_delete(run_id)
         return True
+
+    async def delete_workflow_run(
+        self, run_id: str, deletion_reason: str = user_deletion_reason
+    ) -> bool:
+        if not await self._init_delete(run_id, deletion_reason):
+            return False
+
+        return await self._finish_delete_workflow_run(run_id)
 
     async def run(self):
         appname = "terravibes-data-ops"
@@ -358,5 +576,8 @@ DataOpsConfig = builds(
     max_log_file_bytes=MAX_LOG_FILE_BYTES,
     log_backup_count=LOG_BACKUP_COUNT,
     loglevel=None,
+    max_full_history_runs=DEFAULT_MAX_FULL_HISTORY_RUNS,
+    max_compact_history_runs=DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+    scan_redis_workflow_state=False,
     otel_service_name="",
 )

--- a/src/vibe_agent/vibe_agent/data_ops.py
+++ b/src/vibe_agent/vibe_agent/data_ops.py
@@ -76,6 +76,7 @@ class DataOpsManager:
     otel_service_name: str
     statestore_lock: asyncio.Lock
     history_maintenance_lock: asyncio.Lock
+    history_maintenance_wakeup: asyncio.Event
     history_maintenance_task: Optional[asyncio.Task[None]]
     history_compaction_offset: int
     history_deletion_offset: int
@@ -136,6 +137,7 @@ class DataOpsManager:
         self.metadata_store_lock = RWLock(fast=True)
         self.statestore_lock = asyncio.Lock()
         self.history_maintenance_lock = asyncio.Lock()
+        self.history_maintenance_wakeup = asyncio.Event()
         self.history_compaction_offset = 0
         self.history_deletion_offset = 0
 
@@ -247,7 +249,9 @@ class DataOpsManager:
                 MessageType.workflow_execution_request,
                 MessageType.workflow_deletion_request,
             }:
-                await self._maintain_history_safely()
+                task = self.history_maintenance_task
+                if task is not None and not task.done():
+                    self.history_maintenance_wakeup.set()
 
             return TopicEventResponseStatus.success
 
@@ -339,18 +343,29 @@ class DataOpsManager:
             run_data["output"] = ""
             await self.statestore.store(run_id, run_data)
 
-    async def _maintain_history_safely(self) -> None:
+    async def _maintain_history_safely(self) -> bool:
         try:
             await self.maintain_history()
+            return True
         except asyncio.CancelledError:
             raise
         except Exception:
             logging.exception("Failed to maintain workflow run history")
+            return False
 
     async def _maintain_history_periodically(self) -> None:
         while True:
-            await self._maintain_history_safely()
-            await asyncio.sleep(HISTORY_MAINTENANCE_INTERVAL_S)
+            self.history_maintenance_wakeup.clear()
+            if not await self._maintain_history_safely():
+                await asyncio.sleep(HISTORY_MAINTENANCE_INTERVAL_S)
+                continue
+            try:
+                await asyncio.wait_for(
+                    self.history_maintenance_wakeup.wait(),
+                    HISTORY_MAINTENANCE_INTERVAL_S,
+                )
+            except asyncio.TimeoutError:
+                pass
 
     async def maintain_history(self) -> None:
         """Compact and delete a bounded slice of old workflow history."""

--- a/src/vibe_agent/vibe_agent/data_ops.py
+++ b/src/vibe_agent/vibe_agent/data_ops.py
@@ -48,6 +48,7 @@ DEFAULT_MAX_FULL_HISTORY_RUNS = 100
 DEFAULT_MAX_COMPACT_HISTORY_RUNS = 900
 HISTORY_MAINTENANCE_BATCH_SIZE = 10
 HISTORY_MAINTENANCE_SCAN_SIZE = 100
+HISTORY_MAINTENANCE_INTERVAL_S = 60
 HISTORY_INDEX_UPDATE_RETRIES = 3
 WORKFLOW_TASK_KEY_PATTERN = "????????-????-????-????-????????????-*"
 
@@ -75,6 +76,7 @@ class DataOpsManager:
     otel_service_name: str
     statestore_lock: asyncio.Lock
     history_maintenance_lock: asyncio.Lock
+    history_maintenance_task: Optional[asyncio.Task[None]]
     history_compaction_offset: int
     history_deletion_offset: int
     legacy_task_keys: Optional[Dict[str, List[str]]]
@@ -125,6 +127,7 @@ class DataOpsManager:
         self.max_compact_history_runs = max_compact_history_runs
         self.scan_redis_workflow_state = scan_redis_workflow_state
         self.legacy_task_keys = None
+        self.history_maintenance_task = None
 
         self._setup_routes()
 
@@ -135,17 +138,34 @@ class DataOpsManager:
         self.history_maintenance_lock = asyncio.Lock()
         self.history_compaction_offset = 0
         self.history_deletion_offset = 0
-        self.history_maintenance_task: Optional[asyncio.Task[None]] = None
 
     def _setup_routes(self):
         @self.app.startup()
         def startup():
+            if (
+                self.history_maintenance_task is not None
+                and not self.history_maintenance_task.done()
+            ):
+                return
             # locks have to be be created on the app's (uvicorn's) event loop
             self._init_locks()
+            if self.max_full_history_runs is None:
+                return
             # Dapr is not available until the app startup hook returns.
             self.history_maintenance_task = asyncio.create_task(
-                self._maintain_history_safely()
+                self._maintain_history_periodically()
             )
+
+        @self.app.shutdown()
+        async def shutdown():
+            if self.history_maintenance_task is None:
+                return
+            self.history_maintenance_task.cancel()
+            try:
+                await self.history_maintenance_task
+            except asyncio.CancelledError:
+                pass
+            self.history_maintenance_task = None
 
         @self.app.subscribe_async(self.pubsubname, self.status_topic)
         async def fetch_work(event: v1.Event) -> TopicEventResponse:
@@ -322,8 +342,15 @@ class DataOpsManager:
     async def _maintain_history_safely(self) -> None:
         try:
             await self.maintain_history()
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logging.exception("Failed to maintain workflow run history")
+
+    async def _maintain_history_periodically(self) -> None:
+        while True:
+            await self._maintain_history_safely()
+            await asyncio.sleep(HISTORY_MAINTENANCE_INTERVAL_S)
 
     async def maintain_history(self) -> None:
         """Compact and delete a bounded slice of old workflow history."""

--- a/src/vibe_agent/vibe_agent/launch_data_ops.py
+++ b/src/vibe_agent/vibe_agent/launch_data_ops.py
@@ -10,7 +10,11 @@ from hydra_zen import instantiate, make_config
 
 from vibe_agent.agent_config import DebugConfig, aks_cosmos_config, local_storage
 from vibe_agent.cache_metadata_store import RedisCacheMetadataStoreConfig
-from vibe_agent.data_ops import DataOpsConfig
+from vibe_agent.data_ops import (
+    DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+    DEFAULT_MAX_FULL_HISTORY_RUNS,
+    DataOpsConfig,
+)
 
 # Create instiatiatable configs for CacheMetadataStoreProtocol
 redis_cache_metadata_store_config = RedisCacheMetadataStoreConfig()
@@ -20,6 +24,8 @@ redis_cache_metadata_store_config = RedisCacheMetadataStoreConfig()
 local_data_ops_config = DataOpsConfig(
     metadata_store=redis_cache_metadata_store_config,
     storage=local_storage,
+    max_full_history_runs=DEFAULT_MAX_FULL_HISTORY_RUNS,
+    max_compact_history_runs=DEFAULT_MAX_COMPACT_HISTORY_RUNS,
     scan_redis_workflow_state=True,
 )
 aks_data_ops_config = DataOpsConfig(

--- a/src/vibe_agent/vibe_agent/launch_data_ops.py
+++ b/src/vibe_agent/vibe_agent/launch_data_ops.py
@@ -18,7 +18,9 @@ redis_cache_metadata_store_config = RedisCacheMetadataStoreConfig()
 # create two DataOpsConfigs: one to build DataOpsManager with local storage and another for
 # to build DataOpsManager with AKS/Cosmos storage
 local_data_ops_config = DataOpsConfig(
-    metadata_store=redis_cache_metadata_store_config, storage=local_storage
+    metadata_store=redis_cache_metadata_store_config,
+    storage=local_storage,
+    scan_redis_workflow_state=True,
 )
 aks_data_ops_config = DataOpsConfig(
     metadata_store=redis_cache_metadata_store_config, storage=aks_cosmos_config

--- a/src/vibe_agent/vibe_agent/launch_data_ops.py
+++ b/src/vibe_agent/vibe_agent/launch_data_ops.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import asyncio
+import os
 from typing import Any
 
 import hydra
@@ -19,13 +20,22 @@ from vibe_agent.data_ops import (
 # Create instiatiatable configs for CacheMetadataStoreProtocol
 redis_cache_metadata_store_config = RedisCacheMetadataStoreConfig()
 
+
+def history_limit(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
 # create two DataOpsConfigs: one to build DataOpsManager with local storage and another for
 # to build DataOpsManager with AKS/Cosmos storage
 local_data_ops_config = DataOpsConfig(
     metadata_store=redis_cache_metadata_store_config,
     storage=local_storage,
-    max_full_history_runs=DEFAULT_MAX_FULL_HISTORY_RUNS,
-    max_compact_history_runs=DEFAULT_MAX_COMPACT_HISTORY_RUNS,
+    max_full_history_runs=history_limit(
+        "MAX_FULL_HISTORY_RUNS", DEFAULT_MAX_FULL_HISTORY_RUNS
+    ),
+    max_compact_history_runs=history_limit(
+        "MAX_COMPACT_HISTORY_RUNS", DEFAULT_MAX_COMPACT_HISTORY_RUNS
+    ),
     scan_redis_workflow_state=True,
 )
 aks_data_ops_config = DataOpsConfig(

--- a/src/vibe_common/tests/test_statestore.py
+++ b/src/vibe_common/tests/test_statestore.py
@@ -45,10 +45,11 @@ async def test_retrieve_returns_etag():
         return_value=MockResponse(json.dumps({"value": 1}), {"ETag": "7"})
     )
 
-    value, etag = await store.retrieve_with_etag("key")
+    value, etag = await store.retrieve_with_etag("key", consistency="strong")
 
     assert value == {"value": 1}
     assert etag == "7"
+    assert store.vibe_dapr_client.get.call_args.kwargs["params"]["consistency"] == "strong"
 
 
 @pytest.mark.anyio
@@ -63,10 +64,36 @@ async def test_delete_uses_transaction_delete_operation():
 
 
 @pytest.mark.anyio
+async def test_store_if_absent_uses_portable_first_write():
+    store = StateStore()
+    store.vibe_dapr_client.post = AsyncMock(return_value=MockResponse(""))
+
+    await store.store_if_absent("runs", [])
+
+    request = store.vibe_dapr_client.post.call_args.kwargs["data"][0]
+    assert "etag" not in request
+    assert request["options"] == {
+        "concurrency": "first-write",
+        "consistency": "strong",
+    }
+
+
+@pytest.mark.anyio
+async def test_store_if_absent_reports_redis_create_conflict():
+    store = StateStore()
+    store.vibe_dapr_client.post = AsyncMock(
+        return_value=MockResponse("failed to set key runs", ok=False, status=500)
+    )
+
+    with pytest.raises(StateStoreConflictError):
+        await store.store_if_absent("runs", [])
+
+
+@pytest.mark.anyio
 async def test_transaction_reports_etag_conflict():
     store = StateStore()
     store.vibe_dapr_client.post = AsyncMock(
-        return_value=MockResponse("possible etag mismatch", ok=False, status=500)
+        return_value=MockResponse("failed to set key runs", ok=False, status=500)
     )
 
     with pytest.raises(StateStoreConflictError):

--- a/src/vibe_common/tests/test_statestore.py
+++ b/src/vibe_common/tests/test_statestore.py
@@ -1,19 +1,33 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from typing import Any
+import json
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock
 
 import pytest
 
-from vibe_common.statestore import StateStore
+from vibe_common.statestore import StateStore, StateStoreConflictError
 
 
 class MockResponse:
-    def __init__(self, content: Any):
+    def __init__(
+        self,
+        content: Any,
+        headers: Optional[Dict[str, str]] = None,
+        ok: bool = True,
+        status: int = 200,
+    ):
         self._content = content
+        self.headers = headers or {}
+        self.ok = ok
+        self.status = status
 
     async def json(self, loads: Any, **kwargs: Any) -> Any:
         return loads(self._content, **kwargs)
+
+    async def text(self) -> str:
+        return str(self._content)
 
 
 @pytest.mark.anyio
@@ -22,3 +36,48 @@ async def test_store_fails_with_invalid_input():
     for value in [float(x) for x in "inf -inf nan".split()]:
         with pytest.raises(ValueError):
             await store.store("key", value)
+
+
+@pytest.mark.anyio
+async def test_retrieve_returns_etag():
+    store = StateStore()
+    store.vibe_dapr_client.get = AsyncMock(
+        return_value=MockResponse(json.dumps({"value": 1}), {"ETag": "7"})
+    )
+
+    value, etag = await store.retrieve_with_etag("key")
+
+    assert value == {"value": 1}
+    assert etag == "7"
+
+
+@pytest.mark.anyio
+async def test_delete_uses_transaction_delete_operation():
+    store = StateStore()
+    store.vibe_dapr_client.post = AsyncMock(return_value=MockResponse(""))
+
+    await store.delete("key")
+
+    request = store.vibe_dapr_client.post.call_args.kwargs["data"]
+    assert request["operations"] == [{"operation": "delete", "request": {"key": "key"}}]
+
+
+@pytest.mark.anyio
+async def test_transaction_reports_etag_conflict():
+    store = StateStore()
+    store.vibe_dapr_client.post = AsyncMock(
+        return_value=MockResponse("possible etag mismatch", ok=False, status=500)
+    )
+
+    with pytest.raises(StateStoreConflictError):
+        await store.transaction(
+            [
+                {
+                    "key": "runs",
+                    "operation": "upsert",
+                    "value": [],
+                    "etag": "1",
+                    "options": {"concurrency": "first-write"},
+                }
+            ]
+        )

--- a/src/vibe_common/tests/test_statestore.py
+++ b/src/vibe_common/tests/test_statestore.py
@@ -53,6 +53,32 @@ async def test_retrieve_returns_etag():
 
 
 @pytest.mark.anyio
+async def test_bulk_existing_retries_only_missing_entries():
+    store = StateStore()
+    store.vibe_dapr_client.post = AsyncMock(
+        return_value=MockResponse(
+            json.dumps(
+                [
+                    {"key": "first", "data": {"value": 1}},
+                    {"key": "missing", "data": None},
+                    {"key": "last", "data": {"value": 3}},
+                ]
+            )
+        )
+    )
+    store.retrieve = AsyncMock(return_value={"value": 2})
+
+    values = await store.retrieve_bulk_existing(["first", "missing", "last"])
+
+    assert values == {
+        "first": {"value": 1},
+        "missing": {"value": 2},
+        "last": {"value": 3},
+    }
+    store.retrieve.assert_awaited_once_with("missing")
+
+
+@pytest.mark.anyio
 async def test_delete_uses_transaction_delete_operation():
     store = StateStore()
     store.vibe_dapr_client.post = AsyncMock(return_value=MockResponse(""))

--- a/src/vibe_common/vibe_common/dropdapr.py
+++ b/src/vibe_common/vibe_common/dropdapr.py
@@ -149,7 +149,7 @@ class App:
         return decorator
 
     def startup(self):
-        def decorator(func: Callable[[], None]):
+        def decorator(func: Callable[[], Union[None, Awaitable[None]]]):
             self.app.add_event_handler("startup", func)
 
         return decorator

--- a/src/vibe_common/vibe_common/dropdapr.py
+++ b/src/vibe_common/vibe_common/dropdapr.py
@@ -149,7 +149,7 @@ class App:
         return decorator
 
     def startup(self):
-        def decorator(func: Callable[[], Union[None, Awaitable[None]]]):
+        def decorator(func: Callable[[], None]):
             self.app.add_event_handler("startup", func)
 
         return decorator

--- a/src/vibe_common/vibe_common/statestore.py
+++ b/src/vibe_common/vibe_common/statestore.py
@@ -4,6 +4,7 @@
 
 # -*- coding: utf-8 -*-
 
+import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 
@@ -43,6 +44,8 @@ class StateStoreProtocol(Protocol):
         parallelism: int = DEFAULT_BULK_PARALLELISM,
         traceparent: Optional[str] = None,
     ) -> List[Any]: ...
+
+    async def retrieve_bulk_existing(self, keys: List[str]) -> Dict[str, Any]: ...
 
     async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None: ...
 
@@ -119,6 +122,30 @@ class StateStore(StateStoreProtocol):
         if missing:
             raise KeyError(f"Failed to retrieve keys {missing} from state store.")
         return [state_by_key[key] for key in keys]
+
+    async def retrieve_bulk_existing(self, keys: List[str]) -> Dict[str, Any]:
+        if not keys:
+            return {}
+        try:
+            values = await self.retrieve_bulk(keys)
+            if len(values) == len(keys):
+                return {key: value for key, value in zip(keys, values) if value is not None}
+        except KeyError:
+            pass
+
+        async def retrieve_one(key: str) -> Tuple[str, Optional[Any]]:
+            try:
+                return key, await self.retrieve(key)
+            except KeyError:
+                return key, None
+
+        existing: Dict[str, Any] = {}
+        for start in range(0, len(keys), DEFAULT_BULK_PARALLELISM):
+            chunk = keys[start : start + DEFAULT_BULK_PARALLELISM]
+            for key, value in await asyncio.gather(*(retrieve_one(key) for key in chunk)):
+                if value is not None:
+                    existing[key] = value
+        return existing
 
     async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None:
         response = await self.vibe_dapr_client.post(

--- a/src/vibe_common/vibe_common/statestore.py
+++ b/src/vibe_common/vibe_common/statestore.py
@@ -28,14 +28,17 @@ class TransactionOperation(TypedDict):
 
 
 class StateStoreConflictError(RuntimeError):
-    """Raised when an optimistic state-store transaction loses a race."""
+    """Raised when an optimistic state-store write loses a race."""
 
 
 class StateStoreProtocol(Protocol):
     async def retrieve(self, key: str, traceparent: Optional[str] = None) -> Any: ...
 
     async def retrieve_with_etag(
-        self, key: str, traceparent: Optional[str] = None
+        self,
+        key: str,
+        traceparent: Optional[str] = None,
+        consistency: Optional[str] = None,
     ) -> Tuple[Any, Optional[str]]: ...
 
     async def retrieve_bulk(
@@ -48,6 +51,10 @@ class StateStoreProtocol(Protocol):
     async def retrieve_bulk_existing(self, keys: List[str]) -> Dict[str, Any]: ...
 
     async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None: ...
+
+    async def store_if_absent(
+        self, key: str, obj: Any, traceparent: Optional[str] = None
+    ) -> None: ...
 
     async def delete(self, key: str, traceparent: Optional[str] = None) -> None: ...
 
@@ -72,13 +79,19 @@ class StateStore(StateStoreProtocol):
         return value
 
     async def retrieve_with_etag(
-        self, key: str, traceparent: Optional[str] = None
+        self,
+        key: str,
+        traceparent: Optional[str] = None,
+        consistency: Optional[str] = None,
     ) -> Tuple[Any, Optional[str]]:
         try:
+            params = {"metadata.partitionKey": self.partition_key}
+            if consistency is not None:
+                params["consistency"] = consistency
             response = await self.vibe_dapr_client.get(
                 STATE_URL_TEMPLATE.format(self.state_store, key),
                 traceparent=traceparent,
-                params={"metadata.partitionKey": self.partition_key},
+                params=params,
             )
 
             return (
@@ -161,6 +174,27 @@ class StateStore(StateStoreProtocol):
         )
         assert response.ok, "Failed to store state, but underlying method didn't capture it"
 
+    async def store_if_absent(
+        self, key: str, obj: Any, traceparent: Optional[str] = None
+    ) -> None:
+        response = await self.vibe_dapr_client.post(
+            STATE_URL_TEMPLATE.format(self.state_store, ""),
+            data=[
+                {
+                    "key": key,
+                    "value": self.vibe_dapr_client.obj_json(obj),
+                    "options": {
+                        "concurrency": "first-write",
+                        "consistency": "strong",
+                    },
+                    "metadata": {"partitionKey": self.partition_key},
+                }
+            ],
+            traceparent=traceparent,
+        )
+        if not response.ok:
+            raise StateStoreConflictError(await response.text())
+
     async def delete(self, key: str, traceparent: Optional[str] = None) -> None:
         await self.transaction(
             [TransactionOperation(key=key, operation="delete")],
@@ -191,7 +225,11 @@ class StateStore(StateStoreProtocol):
         )
         if not response.ok:
             body = await response.text()
-            if response.status == 409 or any(
+            optimistic_write = any(
+                operation.get("options", {}).get("concurrency") == "first-write"
+                for operation in operations
+            )
+            if optimistic_write or response.status == 409 or any(
                 marker in body.lower() for marker in ("etag", "first-write", "conflict")
             ):
                 raise StateStoreConflictError(body)

--- a/src/vibe_common/vibe_common/statestore.py
+++ b/src/vibe_common/vibe_common/statestore.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional, Protocol, Tuple
+from typing import Any, Dict, List, Optional, Protocol, Set, Tuple
 
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -29,6 +29,12 @@ class TransactionOperation(TypedDict):
 
 class StateStoreConflictError(RuntimeError):
     """Raised when an optimistic state-store write loses a race."""
+
+
+class _StateStoreBulkError(KeyError):
+    def __init__(self, missing: Set[str], values: Dict[str, Optional[Any]]):
+        super().__init__(f"Failed to retrieve keys {missing} from state store.")
+        self.values = values
 
 
 class StateStoreProtocol(Protocol):
@@ -131,9 +137,10 @@ class StateStore(StateStoreProtocol):
             for state in states
             if isinstance(state, dict) and "key" in state
         }
+
         missing = {key for key in keys if state_by_key.get(key) is None}
         if missing:
-            raise KeyError(f"Failed to retrieve keys {missing} from state store.")
+            raise _StateStoreBulkError(missing, state_by_key)
         return [state_by_key[key] for key in keys]
 
     async def retrieve_bulk_existing(self, keys: List[str]) -> Dict[str, Any]:
@@ -141,10 +148,11 @@ class StateStore(StateStoreProtocol):
             return {}
         try:
             values = await self.retrieve_bulk(keys)
-            if len(values) == len(keys):
-                return {key: value for key, value in zip(keys, values) if value is not None}
+            state_by_key = dict(zip(keys, values))
+        except _StateStoreBulkError as e:
+            state_by_key = e.values
         except KeyError:
-            pass
+            state_by_key = {}
 
         async def retrieve_one(key: str) -> Tuple[str, Optional[Any]]:
             try:
@@ -152,9 +160,14 @@ class StateStore(StateStoreProtocol):
             except KeyError:
                 return key, None
 
-        existing: Dict[str, Any] = {}
-        for start in range(0, len(keys), DEFAULT_BULK_PARALLELISM):
-            chunk = keys[start : start + DEFAULT_BULK_PARALLELISM]
+        existing = {
+            key: state_by_key[key]
+            for key in keys
+            if key in state_by_key and state_by_key[key] is not None
+        }
+        missing = [key for key in keys if key not in existing]
+        for start in range(0, len(missing), DEFAULT_BULK_PARALLELISM):
+            chunk = missing[start : start + DEFAULT_BULK_PARALLELISM]
             for key, value in await asyncio.gather(*(retrieve_one(key) for key in chunk)):
                 if value is not None:
                     existing[key] = value

--- a/src/vibe_common/vibe_common/statestore.py
+++ b/src/vibe_common/vibe_common/statestore.py
@@ -5,7 +5,9 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Any, List, Optional, Protocol, TypedDict
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+from typing_extensions import NotRequired, Required, TypedDict
 
 from vibe_common.constants import STATE_URL_TEMPLATE
 from vibe_common.vibe_dapr_client import VibeDaprClient
@@ -16,23 +18,35 @@ METADATA = {"partitionKey": "eywa"}
 
 
 class TransactionOperation(TypedDict):
-    key: str
-    operation: str
-    value: Optional[Any]
+    key: Required[str]
+    operation: Required[str]
+    value: NotRequired[Optional[Any]]
+    etag: NotRequired[str]
+    options: NotRequired[Dict[str, str]]
+
+
+class StateStoreConflictError(RuntimeError):
+    """Raised when an optimistic state-store transaction loses a race."""
 
 
 class StateStoreProtocol(Protocol):
     async def retrieve(self, key: str, traceparent: Optional[str] = None) -> Any: ...
 
+    async def retrieve_with_etag(
+        self, key: str, traceparent: Optional[str] = None
+    ) -> Tuple[Any, Optional[str]]: ...
+
     async def retrieve_bulk(
         self, keys: List[str], parallelism: int = 2, traceparent: Optional[str] = None
     ) -> List[Any]: ...
 
-    async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> bool: ...
+    async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None: ...
+
+    async def delete(self, key: str, traceparent: Optional[str] = None) -> None: ...
 
     async def transaction(
         self, operations: List[TransactionOperation], traceparent: Optional[str] = None
-    ) -> bool: ...
+    ) -> None: ...
 
 
 class StateStore(StateStoreProtocol):
@@ -47,14 +61,23 @@ class StateStore(StateStoreProtocol):
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
     async def retrieve(self, key: str, traceparent: Optional[str] = None) -> Any:
+        value, _ = await self.retrieve_with_etag(key, traceparent)
+        return value
+
+    async def retrieve_with_etag(
+        self, key: str, traceparent: Optional[str] = None
+    ) -> Tuple[Any, Optional[str]]:
         try:
             response = await self.vibe_dapr_client.get(
                 STATE_URL_TEMPLATE.format(self.state_store, key),
                 traceparent=traceparent,
-                params={"metadata.partitionKey": METADATA["partitionKey"]},
+                params={"metadata.partitionKey": self.partition_key},
             )
 
-            return await self.vibe_dapr_client.response_json(response)
+            return (
+                await self.vibe_dapr_client.response_json(response),
+                response.headers.get("ETag"),
+            )
         except KeyError as e:
             raise KeyError(f"Key {key} not found") from e
 
@@ -75,17 +98,20 @@ class StateStore(StateStoreProtocol):
                 "parallelism": parallelism,
             },
             traceparent=traceparent,
-            params={"metadata.partitionKey": METADATA["partitionKey"]},
+            params={"metadata.partitionKey": self.partition_key},
         )
 
         states = await self.vibe_dapr_client.response_json(response)
 
-        if len(states) != len(keys):
-            keyset = set(keys)
-            for state in states:
-                keyset.remove(state[0])
-            raise KeyError(f"Failed to retrieve keys {keyset} from state store.")
-        return [state["data"] for state in states]
+        state_by_key = {
+            state["key"]: state.get("data")
+            for state in states
+            if isinstance(state, dict) and "key" in state
+        }
+        missing = {key for key in keys if state_by_key.get(key) is None}
+        if missing:
+            raise KeyError(f"Failed to retrieve keys {missing} from state store.")
+        return [state_by_key[key] for key in keys]
 
     async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None:
         response = await self.vibe_dapr_client.post(
@@ -101,20 +127,27 @@ class StateStore(StateStoreProtocol):
         )
         assert response.ok, "Failed to store state, but underlying method didn't capture it"
 
+    async def delete(self, key: str, traceparent: Optional[str] = None) -> None:
+        await self.transaction(
+            [TransactionOperation(key=key, operation="delete")],
+            traceparent=traceparent,
+        )
+
     async def transaction(
         self, operations: List[TransactionOperation], traceparent: Optional[str] = None
     ) -> None:
-        queries = [
-            {
-                "operation": o["operation"],
-                "request": {
-                    "key": o["key"],
-                    "value": self.vibe_dapr_client.obj_json(o["value"]),
-                },
-            }
-            for o in operations
-        ]
-        await self.vibe_dapr_client.post(
+        queries = []
+        for operation in operations:
+            request: Dict[str, Any] = {"key": operation["key"]}
+            if operation["operation"] != "delete":
+                request["value"] = self.vibe_dapr_client.obj_json(operation.get("value"))
+            if "etag" in operation:
+                request["etag"] = operation["etag"]
+            if "options" in operation:
+                request["options"] = operation["options"]
+            queries.append({"operation": operation["operation"], "request": request})
+
+        response = await self.vibe_dapr_client.post(
             url=STATE_URL_TEMPLATE.format(self.state_store, "transaction"),
             data={
                 "operations": queries,
@@ -122,3 +155,10 @@ class StateStore(StateStoreProtocol):
             },
             traceparent=traceparent,
         )
+        if not response.ok:
+            body = await response.text()
+            if response.status == 409 or any(
+                marker in body.lower() for marker in ("etag", "first-write", "conflict")
+            ):
+                raise StateStoreConflictError(body)
+            raise RuntimeError(f"State store transaction failed: {body}")

--- a/src/vibe_common/vibe_common/statestore.py
+++ b/src/vibe_common/vibe_common/statestore.py
@@ -15,6 +15,7 @@ from vibe_common.vibe_dapr_client import VibeDaprClient
 LOGGER = logging.getLogger(__name__)
 STATE_STORE = "statestore"
 METADATA = {"partitionKey": "eywa"}
+DEFAULT_BULK_PARALLELISM = 8
 
 
 class TransactionOperation(TypedDict):
@@ -37,7 +38,10 @@ class StateStoreProtocol(Protocol):
     ) -> Tuple[Any, Optional[str]]: ...
 
     async def retrieve_bulk(
-        self, keys: List[str], parallelism: int = 2, traceparent: Optional[str] = None
+        self,
+        keys: List[str],
+        parallelism: int = DEFAULT_BULK_PARALLELISM,
+        traceparent: Optional[str] = None,
     ) -> List[Any]: ...
 
     async def store(self, key: str, obj: Any, traceparent: Optional[str] = None) -> None: ...
@@ -82,7 +86,10 @@ class StateStore(StateStoreProtocol):
             raise KeyError(f"Key {key} not found") from e
 
     async def retrieve_bulk(
-        self, keys: List[str], parallelism: int = 8, traceparent: Optional[str] = None
+        self,
+        keys: List[str],
+        parallelism: int = DEFAULT_BULK_PARALLELISM,
+        traceparent: Optional[str] = None,
     ) -> List[Any]:
         """Retrieves keys in bulk.
 

--- a/src/vibe_core/tests/test_local_service_images.py
+++ b/src/vibe_core/tests/test_local_service_images.py
@@ -409,6 +409,8 @@ def test_shared_v2_setup_preserves_checkpointed_options(
         "registry_port": None,
         "redis_image": None,
         "rabbitmq_image": None,
+        "max_full_history_runs": 100,
+        "max_compact_history_runs": 900,
     }
     artifacts = OSArtifacts()
     migrated = local.load_redis_migration_state(

--- a/src/vibe_core/vibe_core/cli/local.py
+++ b/src/vibe_core/vibe_core/cli/local.py
@@ -1235,6 +1235,13 @@ def setup(
     max_compact_history_runs: int = 900,
 ) -> bool:
     log("Updating local cluster" if is_update else "Setting up local cluster")
+    if is_update:
+        log(
+            "Workflow history retention will keep "
+            f"{max_full_history_runs} full runs and {max_compact_history_runs} summaries; "
+            "older eligible terminal runs may be compacted or deleted.",
+            level="warning",
+        )
     os.makedirs(data_path, exist_ok=True)
 
     kubectl = KubectlWrapper(k3d.os_artifacts, k3d.cluster_name)

--- a/src/vibe_core/vibe_core/cli/local.py
+++ b/src/vibe_core/vibe_core/cli/local.py
@@ -1231,6 +1231,8 @@ def setup(
     registry_port: Optional[int] = None,
     redis_image: Optional[str] = None,
     rabbitmq_image: Optional[str] = None,
+    max_full_history_runs: int = 100,
+    max_compact_history_runs: int = 900,
 ) -> bool:
     log("Updating local cluster" if is_update else "Setting up local cluster")
     os.makedirs(data_path, exist_ok=True)
@@ -1648,6 +1650,8 @@ def setup(
             enable_telemetry,
             redis_image,
             rabbitmq_image,
+            max_full_history_runs=max_full_history_runs,
+            max_compact_history_runs=max_compact_history_runs,
             is_update=terraform_is_update,
         )
     if (
@@ -2049,6 +2053,8 @@ def _dispatch_unlocked(
             registry_port=args.registry_port,
             redis_image=args.redis_image,
             rabbitmq_image=args.rabbitmq_image,
+            max_full_history_runs=args.max_full_history_runs,
+            max_compact_history_runs=args.max_compact_history_runs,
         )
     elif args.action in {"destroy", "delete", "remove", "rm"}:
         return destroy(k3d, data_path=data_path)

--- a/src/vibe_core/vibe_core/cli/parsers.py
+++ b/src/vibe_core/vibe_core/cli/parsers.py
@@ -238,13 +238,16 @@ class LocalCliParser(CliParser):
                 "--max-full-history-runs",
                 type=_non_negative_int,
                 default=100,
-                help="Newest workflow runs to retain with task details and output.",
+                help="Newest workflow runs to retain with task details and output; 0 keeps none.",
             )
             command.add_argument(
                 "--max-compact-history-runs",
                 type=_non_negative_int,
                 default=900,
-                help="Compacted workflow run summaries to retain after the full-history tier.",
+                help=(
+                    "Compacted summaries to retain after the full-history tier; "
+                    "0 deletes older eligible runs."
+                ),
             )
             command.add_argument(
                 "--worker-replicas",

--- a/src/vibe_core/vibe_core/cli/parsers.py
+++ b/src/vibe_core/vibe_core/cli/parsers.py
@@ -45,6 +45,13 @@ LOCAL_OTEL_PATH = os.path.join(CORE_DIR, "terraform", "local", "modules", "kuber
 REMOTE_OTEL_PATH = os.path.join(CORE_DIR, "terraform", "aks", "modules", "kubernetes", "otel.tf")
 
 
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
 class CliParser(ABC):
     SUPPORTED_COMMANDS = [
         ("setup", SETUP_HELP, ["create", "new"]),
@@ -226,6 +233,18 @@ class LocalCliParser(CliParser):
                 type=int,
                 default=None,
                 help="Number of log files to keep for each service instance.",
+            )
+            command.add_argument(
+                "--max-full-history-runs",
+                type=_non_negative_int,
+                default=100,
+                help="Newest workflow runs to retain with task details and output.",
+            )
+            command.add_argument(
+                "--max-compact-history-runs",
+                type=_non_negative_int,
+                default=900,
+                help="Compacted workflow run summaries to retain after the full-history tier.",
             )
             command.add_argument(
                 "--worker-replicas",

--- a/src/vibe_core/vibe_core/cli/wrappers.py
+++ b/src/vibe_core/vibe_core/cli/wrappers.py
@@ -494,6 +494,8 @@ class TerraformWrapper:
         redis_image: str = REDIS_IMAGE,
         rabbitmq_image: str = RABBITMQ_IMAGE,
         is_update: bool = False,
+        max_full_history_runs: int = 100,
+        max_compact_history_runs: int = 900,
     ):
         if not is_update:
             self.init(self.os_artifacts.local_directory, False, cleanup_state=True)
@@ -514,6 +516,8 @@ class TerraformWrapper:
             "farmvibes_log_level": log_level,
             "max_log_file_bytes": f"{max_log_file_bytes}" if max_log_file_bytes else "",
             "log_backup_count": f"{log_backup_count}" if log_backup_count else "",
+            "max_full_history_runs": f"{max_full_history_runs}",
+            "max_compact_history_runs": f"{max_compact_history_runs}",
         }
 
         state_file = self.os_artifacts.get_terraform_file("local.tfstate", cluster_name)

--- a/src/vibe_core/vibe_core/client.py
+++ b/src/vibe_core/vibe_core/client.py
@@ -758,6 +758,7 @@ class VibeWorkflowRun(WorkflowRun, MonitoredWorkflowRun):
         self._reason = ""
         self._output = None
         self._task_details = None
+        self._deletion_requested = False
 
     def _convert_output(self, output: Dict[str, Any]) -> BaseVibeDict:
         """Convert the output of the workflow run to a :class:`BaseVibeDict`.
@@ -840,9 +841,11 @@ class VibeWorkflowRun(WorkflowRun, MonitoredWorkflowRun):
     def status(self) -> RunStatus:
         """Get the status of the workflow run."""
         if self._status is not RunStatus.deleted:
-            self._status = cast(
-                RunStatus, RunStatus(self.client.list_runs(self.id)[0]["details.status"])
-            )
+            runs = self.client.list_runs(self.id)
+            if not runs and self._deletion_requested:
+                self._status = RunStatus.deleted
+            else:
+                self._status = cast(RunStatus, RunStatus(runs[0]["details.status"]))
         return self._status
 
     @property
@@ -918,6 +921,7 @@ class VibeWorkflowRun(WorkflowRun, MonitoredWorkflowRun):
 
         """
         self.client.delete_run(self.id)
+        self._deletion_requested = True
         self.status
         return self
 

--- a/src/vibe_core/vibe_core/datamodel.py
+++ b/src/vibe_core/vibe_core/datamodel.py
@@ -196,6 +196,8 @@ class RunConfig(RunConfigInput):
     """The spatio temporal json of the run config."""
     output: str = ""
     """The output of the run."""
+    history_compacted: bool = False
+    """Whether task details and output were removed by history retention."""
 
     def set_output(self, value: OpIOType):  # pydantic won't let us use a property setter
         """Set the output of the run config.

--- a/src/vibe_core/vibe_core/terraform/local/main.tf
+++ b/src/vibe_core/vibe_core/terraform/local/main.tf
@@ -31,6 +31,8 @@ module "services" {
   farmvibes_log_level           = var.farmvibes_log_level
   max_log_file_bytes            = var.max_log_file_bytes
   log_backup_count              = var.log_backup_count
+  max_full_history_runs         = var.max_full_history_runs
+  max_compact_history_runs      = var.max_compact_history_runs
   host_assets_dir               = var.host_assets_dir
   kubernetes_config_path        = var.kubernetes_config_path
   kubernetes_config_context     = var.kubernetes_config_context

--- a/src/vibe_core/vibe_core/terraform/local/variables.tf
+++ b/src/vibe_core/vibe_core/terraform/local/variables.tf
@@ -68,6 +68,16 @@ variable "log_backup_count" {
   description = "Number of log files to keep for each service instance"
 }
 
+variable "max_full_history_runs" {
+  default     = 100
+  description = "Newest workflow runs to retain with full task details and output"
+}
+
+variable "max_compact_history_runs" {
+  default     = 900
+  description = "Compacted workflow run summaries to retain after the full-history tier"
+}
+
 variable "environment" {
   description = "Unused"
   default     = ""

--- a/src/vibe_core/vibe_core/terraform/services/dataops.tf
+++ b/src/vibe_core/vibe_core/terraform/services/dataops.tf
@@ -9,6 +9,8 @@ locals {
       "/opt/conda/bin/vibe-data-ops",
       "data_ops=${var.startup_type}",
       "data_ops.impl.port=3000",
+      "data_ops.impl.max_full_history_runs=${var.max_full_history_runs}",
+      "data_ops.impl.max_compact_history_runs=${var.max_compact_history_runs}",
     ],
     var.otel_service_name != "" ? [
       "data_ops.impl.otel_service_name=${var.otel_service_name}",

--- a/src/vibe_core/vibe_core/terraform/services/dataops.tf
+++ b/src/vibe_core/vibe_core/terraform/services/dataops.tf
@@ -9,8 +9,6 @@ locals {
       "/opt/conda/bin/vibe-data-ops",
       "data_ops=${var.startup_type}",
       "data_ops.impl.port=3000",
-      "data_ops.impl.max_full_history_runs=${var.max_full_history_runs}",
-      "data_ops.impl.max_compact_history_runs=${var.max_compact_history_runs}",
     ],
     var.otel_service_name != "" ? [
       "data_ops.impl.otel_service_name=${var.otel_service_name}",
@@ -23,6 +21,8 @@ locals {
       "data_ops.impl.logdir=${var.log_dir}",
       "data_ops.impl.storage.local_path=/mnt/data/stac",
       "data_ops.impl.storage.asset_manager.local_storage_path=/mnt/data/assets",
+      "data_ops.impl.max_full_history_runs=${var.max_full_history_runs}",
+      "data_ops.impl.max_compact_history_runs=${var.max_compact_history_runs}",
     ],
     var.max_log_file_bytes != "" ? [
       "data_ops.impl.max_log_file_bytes=${var.max_log_file_bytes}"

--- a/src/vibe_core/vibe_core/terraform/services/dataops.tf
+++ b/src/vibe_core/vibe_core/terraform/services/dataops.tf
@@ -21,8 +21,6 @@ locals {
       "data_ops.impl.logdir=${var.log_dir}",
       "data_ops.impl.storage.local_path=/mnt/data/stac",
       "data_ops.impl.storage.asset_manager.local_storage_path=/mnt/data/assets",
-      "data_ops.impl.max_full_history_runs=${var.max_full_history_runs}",
-      "data_ops.impl.max_compact_history_runs=${var.max_compact_history_runs}",
     ],
     var.max_log_file_bytes != "" ? [
       "data_ops.impl.max_log_file_bytes=${var.max_log_file_bytes}"
@@ -150,6 +148,20 @@ resource "kubernetes_deployment" "dataops" {
           env {
             name  = "STAC_COSMOS_CONNECTION_KEY_SECRET"
             value = "stac-cosmos-write-key"
+          }
+          dynamic "env" {
+            for_each = var.local_deployment ? [1] : []
+            content {
+              name  = "MAX_FULL_HISTORY_RUNS"
+              value = tostring(var.max_full_history_runs)
+            }
+          }
+          dynamic "env" {
+            for_each = var.local_deployment ? [1] : []
+            content {
+              name  = "MAX_COMPACT_HISTORY_RUNS"
+              value = tostring(var.max_compact_history_runs)
+            }
           }
           dynamic "volume_mount" {
             for_each = var.local_deployment ? [1] : []

--- a/src/vibe_core/vibe_core/terraform/services/variables.tf
+++ b/src/vibe_core/vibe_core/terraform/services/variables.tf
@@ -102,5 +102,5 @@ variable "farmvibes_log_level" {
 
 variable "environment" {
   description = "Unused"
-  default = ""
+  default     = ""
 }

--- a/src/vibe_core/vibe_core/terraform/services/variables.tf
+++ b/src/vibe_core/vibe_core/terraform/services/variables.tf
@@ -55,6 +55,14 @@ variable "log_backup_count" {
   default = ""
 }
 
+variable "max_full_history_runs" {
+  default = 100
+}
+
+variable "max_compact_history_runs" {
+  default = 900
+}
+
 variable "host_assets_dir" {
   default = ""
 }

--- a/src/vibe_server/tests/test_orchestrator.py
+++ b/src/vibe_server/tests/test_orchestrator.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 
 from asyncio.queues import Queue
+from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 from uuid import uuid4 as uuid
@@ -12,7 +13,7 @@ from uuid import uuid4 as uuid
 import pytest
 from cloudevents.sdk.event import v1
 
-from vibe_common.constants import STATUS_PUBSUB_TOPIC, WORKFLOW_REQUEST_PUBSUB_TOPIC
+from vibe_common.constants import RUNS_KEY, STATUS_PUBSUB_TOPIC, WORKFLOW_REQUEST_PUBSUB_TOPIC
 from vibe_common.dropdapr import TopicEventResponseStatus
 from vibe_common.messaging import (
     ErrorContent,
@@ -211,7 +212,47 @@ async def test_orchestrator_startup_sees_no_runs(retrieve: Mock, retrieve_bulk: 
     retrieve_bulk.return_value = []
     orchestrator = Orchestrator()
     assert await orchestrator.get_unfinished_workflows() == []
-    retrieve_bulk.assert_called_once_with([])
+    retrieve_bulk.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_orchestrator_startup_skips_run_deleted_after_index_snapshot(
+    run_config: Dict[str, Any],
+):
+    removed_id, remaining_id = str(uuid()), str(uuid())
+    removed = deepcopy(run_config)
+    removed["id"] = removed_id
+    remaining = deepcopy(run_config)
+    remaining["id"] = remaining_id
+    state = {removed_id: removed, remaining_id: remaining}
+
+    async def retrieve(key: str):
+        if key == RUNS_KEY:
+            return [removed_id, remaining_id]
+        if key not in state:
+            raise KeyError(key)
+        return deepcopy(state[key])
+
+    async def retrieve_bulk(keys: List[str]):
+        assert keys == [removed_id, remaining_id]
+        state.pop(removed_id)
+        raise KeyError(removed_id)
+
+    orchestrator = Orchestrator()
+    orchestrator.statestore.retrieve = AsyncMock(side_effect=retrieve)
+    orchestrator.statestore.retrieve_bulk = AsyncMock(side_effect=retrieve_bulk)
+    message = Mock()
+    with patch.object(
+        orchestrator, "run_config_to_workflow_message", return_value=message
+    ) as build:
+        with patch.object(
+            orchestrator, "handle_workflow_execution_message", new_callable=AsyncMock
+        ) as resume:
+            await orchestrator._resume_workflows()
+
+    build.assert_called_once()
+    assert str(build.call_args.args[0].id) == remaining_id
+    resume.assert_awaited_once_with(message)
 
 
 @patch("vibe_common.statestore.StateStore.retrieve")
@@ -261,14 +302,14 @@ async def test_orchestrator_startup_sees_unfinished_runs(
         nonlocal first
         if first:
             first = False
-            return run_config["id"]
+            return [run_config["id"]]
         return run_config
 
     _run_ops.return_value = None
     retrieve_sinks.return_value = None
     map_output.return_value = None
     retrieve.side_effect = retrieve_fun
-    retrieve_bulk.return_value = [run_config, run_config, run_config]
+    retrieve_bulk.return_value = [run_config]
     build_return_value = Workflow.build(
         get_fake_workflow_path("single_and_parallel"), fake_ops_dir, fake_workflows_dir
     )
@@ -276,7 +317,7 @@ async def test_orchestrator_startup_sees_unfinished_runs(
     with patch("vibe_server.workflow.workflow.Workflow.build", return_value=build_return_value):
         orchestrator = Orchestrator()
         await orchestrator._resume_workflows()
-        retrieve_bulk.assert_called_once_with(run_config["id"])
+        retrieve_bulk.assert_called_once_with([run_config["id"]])
         _run_ops.assert_called()
 
 

--- a/src/vibe_server/tests/test_orchestrator.py
+++ b/src/vibe_server/tests/test_orchestrator.py
@@ -73,26 +73,30 @@ def make_test_message(
 @patch("vibe_common.statestore.StateStore.store")
 @pytest.mark.anyio
 async def test_orchestrator_add_output(store: Mock, retrieve: Mock, run_config: Dict[str, Any]):
+    run_config["tasks"] = ["task"]
     retrieve.side_effect = lambda _: run_config
     output = cast(OpIOType, {"some-op": {"data": "fake"}})
     statestore = StateStore()
     await WorkflowRunManager.add_output_to_run(run_config["id"], output, statestore)
     run_config["output"] = encode(dump_to_json(output))
-    store.assert_called_with(run_config["id"], RunConfig(**run_config))
+    store.assert_called_with(run_config["id"], run_config)
+    assert store.call_args.args[1]["tasks"] == ["task"]
 
 
 @patch("vibe_common.statestore.StateStore.retrieve")
 @patch("vibe_common.statestore.StateStore.store")
 @pytest.mark.anyio
 async def test_orchestrator_fail_workflow(store: Mock, retrieve: Mock, run_config: Dict[str, Any]):
+    run_config["tasks"] = ["task"]
     retrieve.side_effect = lambda _: run_config
     orchestrator = Orchestrator()
     reason = "fake reason"
     await orchestrator.fail_workflow(run_config["id"], reason)
     run_config["details"]["status"] = RunStatus.failed
     run_config["details"]["reason"] = reason
-    assert store.mock_calls[0][1][1].details.status == RunStatus.failed
-    assert store.mock_calls[0][1][1].details.reason == reason
+    assert store.mock_calls[0][1][1]["details"]["status"] == RunStatus.failed
+    assert store.mock_calls[0][1][1]["details"]["reason"] == reason
+    assert store.mock_calls[0][1][1]["tasks"] == ["task"]
 
 
 def to_cloud_event(msg: WorkMessage) -> v1.Event:

--- a/src/vibe_server/vibe_server/orchestrator.py
+++ b/src/vibe_server/vibe_server/orchestrator.py
@@ -689,15 +689,17 @@ class Orchestrator:
         await asyncio.gather(server_task, resume_call)
 
     async def get_unfinished_workflows(self) -> List[RunConfig]:
-        keys = []
         try:
             keys = await self.statestore.retrieve(RUNS_KEY)
         except KeyError:
-            await self.statestore.store(RUNS_KEY, [])
+            return []
 
-        all_runs = cast(
-            List[RunConfig], [RunConfig(**r) for r in await self.statestore.retrieve_bulk(keys)]
-        )
+        run_state = await self.statestore.retrieve_bulk_existing(keys)
+        all_runs = [
+            RunConfig(**run_state[key])
+            for key in keys
+            if isinstance(run_state.get(key), dict)
+        ]
         return [r for r in all_runs if not RunStatus.finished(r.details.status)]
 
     def run_config_to_workflow_message(self, run: RunConfig) -> WorkflowExecutionMessage:

--- a/src/vibe_server/vibe_server/orchestrator.py
+++ b/src/vibe_server/vibe_server/orchestrator.py
@@ -5,7 +5,7 @@ import asyncio
 import asyncio.queues
 import logging
 from argparse import ArgumentParser
-from copy import copy
+from copy import copy, deepcopy
 from dataclasses import asdict
 from datetime import datetime
 from functools import partial
@@ -477,10 +477,11 @@ class WorkflowRunManager:
 
     @staticmethod
     async def add_output_to_run(run_id: str, output: OpIOType, statestore: StateStore) -> None:
-        run_data = await statestore.retrieve(run_id)
+        run_data = deepcopy(await statestore.retrieve(run_id))
         run_config = RunConfig(**run_data)
         run_config.set_output(output)
-        await statestore.store(run_id, run_config)
+        run_data["output"] = run_config.output
+        await statestore.store(run_id, run_data)
 
     async def cancel(self):
         self.is_cancelled = True
@@ -495,15 +496,15 @@ async def update_workflow(
     reason: Optional[str] = None,
     dont_update: Callable[[RunStatus], bool] = RunStatus.finished,
 ) -> None:
-    run_data = await statestore.retrieve(run_id)
+    run_data = deepcopy(await statestore.retrieve(run_id))
     run_config = RunConfig(**run_data)
     if dont_update(run_config.details.status):
         return
-    run_config.details.status = new_status
-    run_config.details.reason = reason if reason else ""
+    run_data["details"]["status"] = new_status
+    run_data["details"]["reason"] = reason if reason else ""
     if new_status in {RunStatus.failed}:
-        run_config.details.start_time = run_config.details.end_time = datetime.now()
-    await statestore.store(run_id, run_config)
+        run_data["details"]["start_time"] = run_data["details"]["end_time"] = datetime.now()
+    await statestore.store(run_id, run_data)
 
 
 class Orchestrator:

--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -384,7 +384,9 @@ class TerravibesProvider:
                     if new_run is None:
                         new_id, new_run = self.create_new_run(runConfig, run_ids)
                     else:
-                        run_ids.append(cast(str, new_id))
+                        retry_id = cast(str, new_id)
+                        if retry_id not in run_ids:
+                            run_ids.append(retry_id)
                     try:
                         if runs_etag is None:
                             await self.update_run_state(run_ids, new_run)

--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -117,8 +117,6 @@ RunList = Union[List[str], List[Dict[str, Any]], JSONResponse]
 WorkflowList = Union[List[str], Dict[str, Any], JSONResponse]
 CreateRunResponse = Union[Dict[str, Union[UUID, str]], JSONResponse]
 RUN_INDEX_UPDATE_RETRIES = 3
-# Redis accepts any ETag for a missing key, while its stored versions are positive.
-RUN_INDEX_CREATE_ETAG = "-1"
 
 
 class WorkflowReturnFormat(StrEnum):
@@ -385,8 +383,17 @@ class TerravibesProvider:
             new_id: Optional[str] = None
             new_run: Optional[RunConfig] = None
             async with self.run_index_lock:
-                for attempt in range(RUN_INDEX_UPDATE_RETRIES):
+                run_ids, runs_etag = await self.list_runs_from_store_with_etag()
+                if runs_etag is None:
+                    try:
+                        await self.state_store.store_if_absent(RUNS_KEY, [])
+                    except StateStoreConflictError:
+                        pass
                     run_ids, runs_etag = await self.list_runs_from_store_with_etag()
+                    if runs_etag is None:
+                        raise RuntimeError("Failed to initialize the workflow run index")
+
+                for attempt in range(RUN_INDEX_UPDATE_RETRIES):
                     if new_run is None:
                         new_id, new_run = self.create_new_run(runConfig, run_ids)
                     else:
@@ -394,13 +401,14 @@ class TerravibesProvider:
                         if retry_id not in run_ids:
                             run_ids.append(retry_id)
                     try:
-                        await self.update_run_state(
-                            run_ids, new_run, runs_etag or RUN_INDEX_CREATE_ETAG
-                        )
+                        await self.update_run_state(run_ids, new_run, runs_etag)
                         break
                     except StateStoreConflictError:
                         if attempt + 1 == RUN_INDEX_UPDATE_RETRIES:
                             raise
+                        run_ids, runs_etag = await self.list_runs_from_store_with_etag()
+                        if runs_etag is None:
+                            raise RuntimeError("Workflow run index disappeared during update")
 
             assert new_run is not None
             add_span_attributes({"run_id": new_id})
@@ -531,7 +539,7 @@ class TerravibesProvider:
     @add_trace
     async def list_runs_from_store_with_etag(self) -> Tuple[List[str], Optional[str]]:
         try:
-            return await self.state_store.retrieve_with_etag(RUNS_KEY)
+            return await self.state_store.retrieve_with_etag(RUNS_KEY, consistency="strong")
         except KeyError:
             return [], None
 

--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -47,7 +47,7 @@ from vibe_common.constants import (
 from vibe_common.dapr import dapr_ready
 from vibe_common.messaging import WorkMessageBuilder, send
 from vibe_common.secret_provider import DaprSecretConfig
-from vibe_common.statestore import StateStore, TransactionOperation
+from vibe_common.statestore import StateStore, StateStoreConflictError, TransactionOperation
 from vibe_common.telemetry import (
     add_span_attributes,
     add_trace,
@@ -112,6 +112,7 @@ MOUNT_DIR: Final[str] = "/mnt"
 RunList = Union[List[str], List[Dict[str, Any]], JSONResponse]
 WorkflowList = Union[List[str], Dict[str, Any], JSONResponse]
 CreateRunResponse = Union[Dict[str, Union[UUID, str]], JSONResponse]
+RUN_INDEX_UPDATE_RETRIES = 3
 
 
 class WorkflowReturnFormat(StrEnum):
@@ -128,6 +129,7 @@ class TerravibesProvider:
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.state_store = StateStore()
         self.href_handler = href_handler
+        self.run_index_lock = asyncio.Lock()
 
     @add_trace
     def summarize_runs(self, runs: List[RunConfig], fields: List[str] = SUMMARY_DEFAULT_FIELDS):
@@ -281,7 +283,7 @@ class TerravibesProvider:
             run = (await self.get_bulk_runs_by_id([run_id]))[0]
             run_config_user = RunConfigUser.from_runconfig(run)
             return jsonable_encoder(self.href_handler.handle(run_config_user))
-        except KeyError:
+        except (KeyError, IndexError):
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content=asdict(Message(f'Workflow execution "{run_id}" not found')),
@@ -374,13 +376,30 @@ class TerravibesProvider:
             validate_workflow_input(user_input, inputs_spec)
             patch_workflow_sources(user_input, workflow)
 
-            run_ids: List[str] = await self.list_runs_from_store()
-            new_id, new_run = self.create_new_run(runConfig, run_ids)
+            new_id: Optional[str] = None
+            new_run: Optional[RunConfig] = None
+            async with self.run_index_lock:
+                for attempt in range(RUN_INDEX_UPDATE_RETRIES):
+                    run_ids, runs_etag = await self.list_runs_from_store_with_etag()
+                    if new_run is None:
+                        new_id, new_run = self.create_new_run(runConfig, run_ids)
+                    else:
+                        run_ids.append(cast(str, new_id))
+                    try:
+                        if runs_etag is None:
+                            await self.update_run_state(run_ids, new_run)
+                        else:
+                            await self.update_run_state(run_ids, new_run, runs_etag)
+                        break
+                    except StateStoreConflictError:
+                        if attempt + 1 == RUN_INDEX_UPDATE_RETRIES:
+                            raise
+
+            assert new_run is not None
             add_span_attributes({"run_id": new_id})
 
             if new_id is None:
                 raise RuntimeError("Failed to create new run id")
-            await self.update_run_state(run_ids, new_run)
 
             # Update run id with parsed workflow and user input
             new_run.workflow = asdict(workflow.workflow_spec)
@@ -464,17 +483,26 @@ class TerravibesProvider:
         return new_id, new_run
 
     @add_trace
-    async def update_run_state(self, run_ids: List[str], new_run: RunConfig):
+    async def update_run_state(
+        self, run_ids: List[str], new_run: RunConfig, runs_etag: Optional[str] = None
+    ):
+        runs_operation = cast(
+            TransactionOperation,
+            {
+                "key": RUNS_KEY,
+                "operation": "upsert",
+                "value": run_ids,
+            },
+        )
+        if runs_etag is not None:
+            runs_operation["etag"] = runs_etag
+            runs_operation["options"] = {
+                "concurrency": "first-write",
+                "consistency": "strong",
+            }
         await self.state_store.transaction(
             [
-                cast(
-                    TransactionOperation,
-                    {
-                        "key": RUNS_KEY,
-                        "operation": "upsert",
-                        "value": run_ids,
-                    },
-                ),
+                runs_operation,
                 cast(
                     TransactionOperation,
                     {
@@ -495,16 +523,65 @@ class TerravibesProvider:
             return []
 
     @add_trace
+    async def list_runs_from_store_with_etag(self) -> Tuple[List[str], Optional[str]]:
+        try:
+            return await self.state_store.retrieve_with_etag(RUNS_KEY)
+        except KeyError:
+            return [], None
+
+    @add_trace
     async def get_bulk_runs_by_id(self, run_ids: Union[List[str], List[UUID]]) -> List[RunConfig]:
-        run_data = await self.state_store.retrieve_bulk([str(id) for id in run_ids])
-        run_id_to_data = {r["id"]: r for r in run_data}
-        run_task_ids = [(r["id"], task) for r in run_data for task in r.get("tasks", [])]
-        task_data = await self.state_store.retrieve_bulk([f"{i[0]}-{i[1]}" for i in run_task_ids])
-        for run_task_id, task_datum in zip(run_task_ids, task_data):
-            run_id, task_name = run_task_id
-            run_datum = run_id_to_data[run_id]
-            run_datum["task_details"][task_name] = task_datum
-        runs = [RunConfig(**cast(Dict[str, Any], data)) for data in run_data]
+        async def retrieve_existing(keys: List[str]) -> Dict[str, Any]:
+            if not keys:
+                return {}
+            try:
+                values = await self.state_store.retrieve_bulk(keys)
+                if len(values) == len(keys):
+                    return {key: value for key, value in zip(keys, values) if value is not None}
+            except KeyError:
+                pass
+
+            async def retrieve_one(key: str) -> Tuple[str, Optional[Any]]:
+                try:
+                    return key, await self.state_store.retrieve(key)
+                except KeyError:
+                    return key, None
+
+            return {
+                key: value
+                for key, value in await asyncio.gather(*(retrieve_one(key) for key in keys))
+                if value is not None
+            }
+
+        requested_ids = [str(run_id) for run_id in run_ids]
+        run_state = await retrieve_existing(requested_ids)
+        ordered_run_data = [
+            run_state[run_id] for run_id in requested_ids if isinstance(run_state.get(run_id), dict)
+        ]
+        run_task_ids = [
+            (str(run_data.get("id", "")), task)
+            for run_data in ordered_run_data
+            for task in run_data.get("tasks", [])
+        ]
+        task_keys = [f"{run_id}-{task}" for run_id, task in run_task_ids]
+        task_state = await retrieve_existing(task_keys)
+        for run_data in ordered_run_data:
+            run_data.setdefault("task_details", {})
+            run_id = str(run_data.get("id", ""))
+            for task in run_data.get("tasks", []):
+                task_key = f"{run_id}-{task}"
+                if task_key in task_state:
+                    run_data["task_details"][task] = task_state[task_key]
+
+        runs = []
+        for run_data in ordered_run_data:
+            try:
+                runs.append(RunConfig(**cast(Dict[str, Any], run_data)))
+            except (TypeError, ValueError, pydantic.ValidationError):
+                self.logger.warning(
+                    f"Ignoring invalid or concurrently deleted workflow run "
+                    f"{run_data.get('id', '<unknown>')}"
+                )
         return runs
 
     def submit_work(self, new_run: RunConfig):

--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -48,7 +48,6 @@ from vibe_common.dapr import dapr_ready
 from vibe_common.messaging import WorkMessageBuilder, send
 from vibe_common.secret_provider import DaprSecretConfig
 from vibe_common.statestore import (
-    DEFAULT_BULK_PARALLELISM,
     StateStore,
     StateStoreConflictError,
     TransactionOperation,
@@ -118,6 +117,8 @@ RunList = Union[List[str], List[Dict[str, Any]], JSONResponse]
 WorkflowList = Union[List[str], Dict[str, Any], JSONResponse]
 CreateRunResponse = Union[Dict[str, Union[UUID, str]], JSONResponse]
 RUN_INDEX_UPDATE_RETRIES = 3
+# Redis accepts any ETag for a missing key, while its stored versions are positive.
+RUN_INDEX_CREATE_ETAG = "-1"
 
 
 class WorkflowReturnFormat(StrEnum):
@@ -393,10 +394,9 @@ class TerravibesProvider:
                         if retry_id not in run_ids:
                             run_ids.append(retry_id)
                     try:
-                        if runs_etag is None:
-                            await self.update_run_state(run_ids, new_run)
-                        else:
-                            await self.update_run_state(run_ids, new_run, runs_etag)
+                        await self.update_run_state(
+                            run_ids, new_run, runs_etag or RUN_INDEX_CREATE_ETAG
+                        )
                         break
                     except StateStoreConflictError:
                         if attempt + 1 == RUN_INDEX_UPDATE_RETRIES:
@@ -491,7 +491,7 @@ class TerravibesProvider:
 
     @add_trace
     async def update_run_state(
-        self, run_ids: List[str], new_run: RunConfig, runs_etag: Optional[str] = None
+        self, run_ids: List[str], new_run: RunConfig, runs_etag: str
     ):
         runs_operation = cast(
             TransactionOperation,
@@ -499,14 +499,13 @@ class TerravibesProvider:
                 "key": RUNS_KEY,
                 "operation": "upsert",
                 "value": run_ids,
+                "etag": runs_etag,
+                "options": {
+                    "concurrency": "first-write",
+                    "consistency": "strong",
+                },
             },
         )
-        if runs_etag is not None:
-            runs_operation["etag"] = runs_etag
-            runs_operation["options"] = {
-                "concurrency": "first-write",
-                "consistency": "strong",
-            }
         await self.state_store.transaction(
             [
                 runs_operation,
@@ -538,32 +537,8 @@ class TerravibesProvider:
 
     @add_trace
     async def get_bulk_runs_by_id(self, run_ids: Union[List[str], List[UUID]]) -> List[RunConfig]:
-        async def retrieve_existing(keys: List[str]) -> Dict[str, Any]:
-            if not keys:
-                return {}
-            try:
-                values = await self.state_store.retrieve_bulk(keys)
-                if len(values) == len(keys):
-                    return {key: value for key, value in zip(keys, values) if value is not None}
-            except KeyError:
-                pass
-
-            async def retrieve_one(key: str) -> Tuple[str, Optional[Any]]:
-                try:
-                    return key, await self.state_store.retrieve(key)
-                except KeyError:
-                    return key, None
-
-            existing: Dict[str, Any] = {}
-            for start in range(0, len(keys), DEFAULT_BULK_PARALLELISM):
-                chunk = keys[start : start + DEFAULT_BULK_PARALLELISM]
-                for key, value in await asyncio.gather(*(retrieve_one(key) for key in chunk)):
-                    if value is not None:
-                        existing[key] = value
-            return existing
-
         requested_ids = [str(run_id) for run_id in run_ids]
-        run_state = await retrieve_existing(requested_ids)
+        run_state = await self.state_store.retrieve_bulk_existing(requested_ids)
         ordered_run_data = [
             run_state[run_id] for run_id in requested_ids if isinstance(run_state.get(run_id), dict)
         ]
@@ -573,7 +548,7 @@ class TerravibesProvider:
             for task in run_data.get("tasks", [])
         ]
         task_keys = [f"{run_id}-{task}" for run_id, task in run_task_ids]
-        task_state = await retrieve_existing(task_keys)
+        task_state = await self.state_store.retrieve_bulk_existing(task_keys)
         for run_data in ordered_run_data:
             run_data.setdefault("task_details", {})
             run_id = str(run_data.get("id", ""))

--- a/src/vibe_server/vibe_server/server.py
+++ b/src/vibe_server/vibe_server/server.py
@@ -47,7 +47,12 @@ from vibe_common.constants import (
 from vibe_common.dapr import dapr_ready
 from vibe_common.messaging import WorkMessageBuilder, send
 from vibe_common.secret_provider import DaprSecretConfig
-from vibe_common.statestore import StateStore, StateStoreConflictError, TransactionOperation
+from vibe_common.statestore import (
+    DEFAULT_BULK_PARALLELISM,
+    StateStore,
+    StateStoreConflictError,
+    TransactionOperation,
+)
 from vibe_common.telemetry import (
     add_span_attributes,
     add_trace,
@@ -549,11 +554,13 @@ class TerravibesProvider:
                 except KeyError:
                     return key, None
 
-            return {
-                key: value
-                for key, value in await asyncio.gather(*(retrieve_one(key) for key in keys))
-                if value is not None
-            }
+            existing: Dict[str, Any] = {}
+            for start in range(0, len(keys), DEFAULT_BULK_PARALLELISM):
+                chunk = keys[start : start + DEFAULT_BULK_PARALLELISM]
+                for key, value in await asyncio.gather(*(retrieve_one(key) for key in chunk)):
+                    if value is not None:
+                        existing[key] = value
+            return existing
 
         requested_ids = [str(run_id) for run_id in run_ids]
         run_state = await retrieve_existing(requested_ids)


### PR DESCRIPTION
TL;DR: Now redis won't fill the disk any more.

This pull request introduces new tests and test utilities to support workflow run history retention and compaction features, as well as improved handling of run listing and deletion edge cases. It also adds test coverage for Redis key scanning and fixes minor issues in test assertions.

**Test coverage for workflow run history retention and compaction:**

- Added a new section to the client documentation (`CLIENT.md`) describing workflow run history retention, including how recent and compacted runs are managed and how to configure retention limits for local Redis deployments.
- Added tests for handling concurrent run index conflicts and verifying correct retry and etag behavior during workflow submission in `test_rest_api.py`.
- Added tests to ensure compacted and missing runs do not break bulk listing, and that compacted runs return the expected minimal fields.
- Updated tests to use and patch the new `list_runs_from_store_with_etag` method, ensuring compatibility with history compaction logic. [[1]](diffhunk://#diff-6010d1e6eb532fa3b550f19dd66c8fd7e0d44c2c1cc7358e8628e99b2b2cb5f9L149-R243) [[2]](diffhunk://#diff-3a2a8c8f14fb7fb083a31cb00536cbbbc6ada8ced281180f0fca6c2fec0d5f8bR75-R79) [[3]](diffhunk://#diff-3a2a8c8f14fb7fb083a31cb00536cbbbc6ada8ced281180f0fca6c2fec0d5f8bR126-R138) [[4]](diffhunk://#diff-3a2a8c8f14fb7fb083a31cb00536cbbbc6ada8ced281180f0fca6c2fec0d5f8bR169-R173)
- Improved test logic for resubmission and cancellation to account for compacted runs, including setting expected fields in test responses. [[1]](diffhunk://#diff-6010d1e6eb532fa3b550f19dd66c8fd7e0d44c2c1cc7358e8628e99b2b2cb5f9R288-R298) [[2]](diffhunk://#diff-6010d1e6eb532fa3b550f19dd66c8fd7e0d44c2c1cc7358e8628e99b2b2cb5f9R323-R325)

**Test utilities and Redis key scanning:**

- Added a `scan_iter` method to the `AsyncFakeRedis` test utility and a corresponding test for `find_keys`, allowing tests to simulate Redis key prefix scanning. [[1]](diffhunk://#diff-65db95f734d5eb8aa2d81201fda4e12eb52976e12d1af7c3ec3493a1aeab7a29R96-R101) [[2]](diffhunk://#diff-65db95f734d5eb8aa2d81201fda4e12eb52976e12d1af7c3ec3493a1aeab7a29R169-R184)

**Test assertion fixes:**

- Fixed test assertions in `test_cache_metadata_store.py` to correctly access run status in dictionary form after compaction changes. [[1]](diffhunk://#diff-65db95f734d5eb8aa2d81201fda4e12eb52976e12d1af7c3ec3493a1aeab7a29L247-R271) [[2]](diffhunk://#diff-65db95f734d5eb8aa2d81201fda4e12eb52976e12d1af7c3ec3493a1aeab7a29L275-R299)

These changes improve the reliability of workflow history retention and compaction features and ensure robust test coverage for edge cases introduced by these features.