### PR TITLE
Fix Helm provider v3 configuration

### DIFF
--- a/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/providers.tf
+++ b/src/vibe_core/vibe_core/terraform/aks/modules/kubernetes/providers.tf
@@ -43,7 +43,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = var.kubernetes_config_path
     config_context = var.kubernetes_config_context
   }

--- a/src/vibe_core/vibe_core/terraform/services/providers.tf
+++ b/src/vibe_core/vibe_core/terraform/services/providers.tf
@@ -18,10 +18,6 @@ terraform {
       version = ">= 1.7.0"
     }
   }
-
-  backend "kubernetes" {
-    secret_suffix = "terraform-state"
-  }
 }
 
 provider "kubernetes" {
@@ -30,7 +26,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = var.kubernetes_config_path
     config_context = var.kubernetes_config_context
   }


### PR DESCRIPTION
Fresh Terraform initialization can select Helm provider v3 because the repository allows versions newer than 2.7.1, but the shared services and AKS Kubernetes modules still use the removed v2 nested `kubernetes` block. The services module also declares backend state even though it is consumed as a child module.

This PR switches those active provider configurations to object syntax and leaves backend ownership with the root modules. Provider versions and deployment behavior are otherwise unchanged.

Closes #227.