### PR TITLE
Skip invalid Landsat QA asset

### DIFF
--- a/src/vibe_lib/tests/test_planetary_computer.py
+++ b/src/vibe_lib/tests/test_planetary_computer.py
@@ -7,3 +7,4 @@ from vibe_lib.planetary_computer import LandsatCollection
 def test_landsat_collection_excludes_non_raster_qa_asset():
     assert "qa" not in LandsatCollection.asset_keys
     assert "qa_pixel" in LandsatCollection.asset_keys
+    assert "qa_radsat" in LandsatCollection.asset_keys

--- a/src/vibe_lib/tests/test_planetary_computer.py
+++ b/src/vibe_lib/tests/test_planetary_computer.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from vibe_lib.planetary_computer import LandsatCollection
+
+
+def test_landsat_collection_excludes_non_raster_qa_asset():
+    assert "qa" not in LandsatCollection.asset_keys
+    assert "qa_pixel" in LandsatCollection.asset_keys

--- a/src/vibe_lib/vibe_lib/planetary_computer.py
+++ b/src/vibe_lib/vibe_lib/planetary_computer.py
@@ -172,7 +172,6 @@ class NaipCollection(PlanetaryComputerCollection):
 class LandsatCollection(PlanetaryComputerCollection):
     collection = "landsat-c2-l2"
     asset_keys: List[str] = [
-        "qa",
         "red",
         "blue",
         "drad",


### PR DESCRIPTION
The Landsat downloader currently fetches the generic `qa` asset even though no workflow consumes it. For the scene reported in #116, Planetary Computer serves that asset as HTML while advertising it as a TIFF, so stacking fails before the usable `qa_pixel` mask is reached.

This PR removes only the unused `qa` key and keeps `qa_pixel` and `qa_radsat`. A focused regression checks that contract.

Closes #116.