### PR TITLE
Handle legacy local registry names

### DIFF
--- a/src/vibe_core/tests/test_local_service_images.py
+++ b/src/vibe_core/tests/test_local_service_images.py
@@ -289,6 +289,21 @@ def test_destroy_dispatch_uses_saved_storage_path(
     assert captured["data_path"] == str(storage_path / local.DATA_SUFFIX)
 
 
+def test_destroy_old_registry_removes_legacy_container_only(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    docker = Mock()
+    docker.get.side_effect = ("legacy-id", "")
+    monkeypatch.setattr(local, "DockerWrapper", Mock(return_value=docker))
+
+    assert local.destroy_old_registry(Mock(spec=OSArtifacts))
+    assert docker.get.call_args_list == [
+        call("farmvibes-ai-registry"),
+        call("k3d-farmvibes-ai-registry.localhost"),
+    ]
+    docker.rm.assert_called_once_with("farmvibes-ai-registry")
+
+
 def test_pending_setup_preserves_checkpointed_options(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):

--- a/src/vibe_core/tests/test_local_service_images.py
+++ b/src/vibe_core/tests/test_local_service_images.py
@@ -5,6 +5,7 @@ import base64
 import errno
 import json
 import os
+import re
 import socket
 import subprocess
 import threading
@@ -298,10 +299,21 @@ def test_destroy_old_registry_removes_legacy_container_only(
 
     assert local.destroy_old_registry(Mock(spec=OSArtifacts))
     assert docker.get.call_args_list == [
-        call("farmvibes-ai-registry"),
-        call("k3d-farmvibes-ai-registry.localhost"),
+        call(f"^/{re.escape('farmvibes-ai-registry')}$"),
+        call(f"^/{re.escape('k3d-farmvibes-ai-registry.localhost')}$"),
     ]
     docker.rm.assert_called_once_with("farmvibes-ai-registry")
+
+
+def test_destroy_old_registry_removes_modern_container_only(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    docker = Mock()
+    docker.get.side_effect = ("", "modern-id")
+    monkeypatch.setattr(local, "DockerWrapper", Mock(return_value=docker))
+
+    assert local.destroy_old_registry(Mock(spec=OSArtifacts))
+    docker.rm.assert_called_once_with("k3d-farmvibes-ai-registry.localhost")
 
 
 def test_pending_setup_preserves_checkpointed_options(

--- a/src/vibe_core/vibe_core/cli/local.py
+++ b/src/vibe_core/vibe_core/cli/local.py
@@ -1080,16 +1080,15 @@ def restore_redis_data(
     return True
 
 
-def destroy_old_registry(
-    os_artifacts: OSArtifacts, cluster_name: str = OLD_DEFAULT_CLUSTER_NAME
-) -> bool:
-    container_name = f"k3d-{cluster_name}-registry.localhost"
+def destroy_old_registry(os_artifacts: OSArtifacts) -> bool:
     docker = DockerWrapper(os_artifacts)
     try:
-        result = docker.get(container_name)
-        if not result:
-            return True
-        docker.rm(container_name)
+        for container_name in (
+            f"{OLD_DEFAULT_CLUSTER_NAME}-registry",
+            f"k3d-{OLD_DEFAULT_CLUSTER_NAME}-registry.localhost",
+        ):
+            if docker.get(container_name):
+                docker.rm(container_name)
         return True
     except Exception as e:
         log(f"Unable to remove old registry container: {e}", level="warning")

--- a/src/vibe_core/vibe_core/cli/local.py
+++ b/src/vibe_core/vibe_core/cli/local.py
@@ -8,6 +8,7 @@ import errno
 import hashlib
 import json
 import os
+import re
 import secrets
 import shutil
 import tempfile
@@ -1087,7 +1088,7 @@ def destroy_old_registry(os_artifacts: OSArtifacts) -> bool:
             f"{OLD_DEFAULT_CLUSTER_NAME}-registry",
             f"k3d-{OLD_DEFAULT_CLUSTER_NAME}-registry.localhost",
         ):
-            if docker.get(container_name):
+            if docker.get(f"^/{re.escape(container_name)}$"):
                 docker.rm(container_name)
         return True
     except Exception as e:


### PR DESCRIPTION
Clusters created during the registry naming transition can still have a `farmvibes-ai-registry` container, but update cleanup only looks for `k3d-farmvibes-ai-registry.localhost`. The update then leaves the legacy container behind or aborts.

This PR checks only those two known historical names and removes whichever exists. It does not broaden deletion or change current registry setup. A focused regression covers the legacy-first path.

Closes #166.