### PR TITLE
Use the EGI coefficient in irrigation probability

### DIFF
--- a/ops/compute_irrigation_probability/compute_irrigation_probability.py
+++ b/ops/compute_irrigation_probability/compute_irrigation_probability.py
@@ -72,7 +72,7 @@ class CallbackBuilder:
             model = LogisticRegression()
 
             # Set the coefficients and intercept
-            coef_ = np.array([[self.coef_ngi, self.coef_ngi, self.coef_lst]])
+            coef_ = np.array([[self.coef_ngi, self.coef_egi, self.coef_lst]])
             intercept_ = [self.intercept]
             classes_ = np.array(["1", "2"])
 

--- a/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
+++ b/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import numpy as np
+import pytest
+import xarray as xr
+from compute_irrigation_probability import CallbackBuilder, LogisticRegression
+
+
+def test_distinct_ngi_egi_coefficients(monkeypatch: pytest.MonkeyPatch):
+    inputs = [object() for _ in range(5)]
+    landsat, cloud_mask, ngi, egi, lst = inputs
+    rasters = {
+        cloud_mask: np.ones((1, 2, 2)),
+        ngi: [[[0, 1], [2, 3]]],
+        egi: [[[3, 2], [1, 0]]],
+        lst: [[[1, 2], [3, 4]]],
+    }
+    captured = {}
+
+    monkeypatch.setattr(
+        "compute_irrigation_probability.load_raster_match",
+        lambda raster, _: xr.DataArray(rasters[raster], dims=("band", "y", "x")),
+    )
+
+    def capture_coefficients(model: LogisticRegression, _: np.ndarray):
+        captured["coef"] = model.coef_
+        raise RuntimeError("stop after coefficient capture")
+
+    monkeypatch.setattr(LogisticRegression, "predict_proba", capture_coefficients)
+
+    with pytest.raises(RuntimeError, match="stop after coefficient capture"):
+        CallbackBuilder(1.0, 2.0, 3.0, 4.0)()(landsat, ngi, egi, lst, cloud_mask)  # type: ignore
+
+    np.testing.assert_array_equal(captured["coef"], [[1.0, 2.0, 3.0]])

--- a/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
+++ b/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
@@ -4,7 +4,8 @@
 import numpy as np
 import pytest
 import xarray as xr
-from compute_irrigation_probability import CallbackBuilder, LogisticRegression
+from compute_irrigation_probability import CallbackBuilder
+from sklearn.linear_model import LogisticRegression
 
 
 def test_distinct_ngi_egi_coefficients(monkeypatch: pytest.MonkeyPatch):
@@ -29,7 +30,11 @@ def test_distinct_ngi_egi_coefficients(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(LogisticRegression, "predict_proba", capture_coefficients)
 
-    with pytest.raises(RuntimeError, match="stop after coefficient capture"):
-        CallbackBuilder(1.0, 2.0, 3.0, 4.0)()(landsat, ngi, egi, lst, cloud_mask)  # type: ignore
+    builder = CallbackBuilder(1.0, 2.0, 3.0, 4.0)
+    try:
+        with pytest.raises(RuntimeError, match="stop after coefficient capture"):
+            builder()(landsat, ngi, egi, lst, cloud_mask)  # type: ignore
+    finally:
+        builder.tmp_dir.cleanup()
 
     np.testing.assert_array_equal(captured["coef"], [[1.0, 2.0, 3.0]])

--- a/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
+++ b/ops/compute_irrigation_probability/test_compute_irrigation_probability.py
@@ -23,7 +23,7 @@ def test_distinct_ngi_egi_coefficients(monkeypatch: pytest.MonkeyPatch):
         lambda raster, _: xr.DataArray(rasters[raster], dims=("band", "y", "x")),
     )
 
-    def capture_coefficients(model: LogisticRegression, _: np.ndarray):
+    def capture_coefficients(model: LogisticRegression, _: object):
         captured["coef"] = model.coef_
         raise RuntimeError("stop after coefficient capture")
 


### PR DESCRIPTION
The irrigation callback accepts separate NGI and EGI coefficients, but the fitted logistic model currently inserts the NGI value twice. That silently gives every probability calculation the wrong EGI weight.

This PR changes the duplicated entry to `coef_egi`. A focused regression uses distinct values and checks the model vector directly.

Addresses the implementation defect found while investigating #223.