### PR TITLE
Use a safe weed-detection buffer default

### DIFF
--- a/ops/weed_detection/test_weed_detection.py
+++ b/ops/weed_detection/test_weed_detection.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+import yaml
+from rasterio.transform import from_bounds
+from shapely import geometry as shpg
+from weed_detection import OpenedRaster
+
+from vibe_core.data import AssetVibe, Raster
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "weed_detection.yaml")
+
+
+def test_wgs84_default_buffer(tmp_path: Path):
+    bounds = (-47.1, -22.9, -47.0, -22.8)
+    raster_path = tmp_path / "raster.tif"
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        width=10,
+        height=10,
+        count=1,
+        dtype=np.uint8,
+        crs="EPSG:4326",
+        transform=from_bounds(*bounds, 10, 10),
+    ) as dataset:
+        dataset.write(np.ones((1, 10, 10), dtype=np.uint8))
+
+    raster = Raster(
+        id="raster",
+        time_range=(datetime(2023, 1, 1), datetime(2023, 1, 1)),
+        geometry=shpg.mapping(shpg.box(*bounds)),
+        assets=[AssetVibe(reference=str(raster_path), type="image/tiff", id="asset")],
+        bands={"band": 0},
+    )
+    with open(CONFIG_PATH) as config:
+        buffer = yaml.safe_load(config)["parameters"]["buffer"]
+
+    assert buffer == 0
+    assert OpenedRaster(raster, buffer, None, -1, []).training_data.shape == (1, 100)
+    with pytest.raises(ValueError, match="creates an empty or invalid geometry"):
+        OpenedRaster(raster, -1, None, -1, [])

--- a/ops/weed_detection/weed_detection.py
+++ b/ops/weed_detection/weed_detection.py
@@ -55,6 +55,11 @@ class OpenedRaster:
             projected_geo = (
                 gpd.GeoSeries(shpg.shape(raster.geometry), crs="epsg:4326").to_crs(src.crs).iloc[0]
             )
+            buffered_geo = projected_geo.buffer(buffer)
+            if buffered_geo.is_empty or not buffered_geo.is_valid:
+                raise ValueError(
+                    f"Buffer {buffer} creates an empty or invalid geometry in raster CRS {src.crs}"
+                )
 
             if no_data is None:
                 no_data = src.nodata
@@ -62,7 +67,7 @@ class OpenedRaster:
             self.input_crs = src.crs
 
         self.buffer_mask = geometry_mask(
-            [projected_geo.buffer(buffer)], ar.shape[1:], self.tr, invert=True
+            [buffered_geo], ar.shape[1:], self.tr, invert=True
         )
 
         # Create an alpha mask

--- a/ops/weed_detection/weed_detection.yaml
+++ b/ops/weed_detection/weed_detection.yaml
@@ -4,7 +4,7 @@ inputs:
 output:
   result: DataVibe
 parameters:
-    buffer: -50
+    buffer: 0
     no_data:
     clusters: 4
     sieve_size: 2000


### PR DESCRIPTION
Weed detection defaults `buffer` to `-50` in raster CRS units. For the WGS84 raster attached to #139, that means negative 50 degrees and collapses the boundary before rasterization.

This PR makes the generic default zero while preserving explicit projected-unit buffers. It also rejects a buffer that creates empty or invalid geometry before rasterization. A focused WGS84 regression covers both paths.

Closes #139.