### PR TITLE
Update COMET-Farm integration for API v2.5

### DIFF
--- a/docs/source/docfiles/markdown/SECRETS.md
+++ b/docs/source/docfiles/markdown/SECRETS.md
@@ -79,6 +79,10 @@ farmvibes-ai <local | remote> delete-secret <key>
   - `data_ingestion/gedi/download_gedi`
   - `data_ingestion/gedi/download_gedi_rh100`
 
+- **COMET-Farm API key** (parameter `comet_api_key` with default secret key `comet-api-key`).
+  - `farm_ai/carbon_local/carbon_whatif`
+  - `farm_ai/carbon_local/admag_carbon_integration`
+
 - **NOAA GFS SAS token** (parameter `noaa_gfs_token` with default secret key `noaa-gfs-sas`).
   - `data_ingestion/weather/get_forecast`
 

--- a/docs/source/docfiles/markdown/workflow_yaml/farm_ai/carbon_local/admag_carbon_integration.md
+++ b/docs/source/docfiles/markdown/workflow_yaml/farm_ai/carbon_local/admag_carbon_integration.md
@@ -41,6 +41,8 @@ Computes the offset amount of carbon that would be sequestered in a seasonal fie
 
 - **comet_support_email**: Comet support email. The email used to register for a COMET account. The requests are forwarded to comet with this email reference.  This email is used by comet to share the information back to you for failed requests.
 
+- **comet_api_key**: COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.
+
 - **ngrok_token**: NGROK session token. A token that FarmVibes uses to create a web_hook url that is shared with Comet in a request when running the workflow. Comet can use this link to send back a response to FarmVibes.  NGROK is a service that creates temporary urls for local servers. To use NGROK, FarmVibes needs to get a token from this website, https://dashboard.ngrok.com/.
 
 ## Tasks
@@ -70,6 +72,7 @@ parameters:
   authority: null
   default_scope: null
   comet_support_email: null
+  comet_api_key: '@SECRET(eywa-secrets, comet-api-key)'
   ngrok_token: null
 tasks:
   baseline_seasonal_field_list:
@@ -92,6 +95,7 @@ tasks:
     workflow: farm_ai/carbon_local/carbon_whatif
     parameters:
       comet_support_email: '@from(comet_support_email)'
+      comet_api_key: '@from(comet_api_key)'
       ngrok_token: '@from(ngrok_token)'
 edges:
 - origin: baseline_seasonal_field_list.seasonal_field
@@ -124,6 +128,8 @@ description:
     comet_support_email: Comet support email. The email used to register for a COMET
       account. The requests are forwarded to comet with this email reference.  This
       email is used by comet to share the information back to you for failed requests.
+    comet_api_key: COMET-Farm API key, loaded from the FarmVibes.AI secret store
+      by default.
     ngrok_token: NGROK session token. A token that FarmVibes uses to create a web_hook
       url that is shared with Comet in a request when running the workflow. Comet
       can use this link to send back a response to FarmVibes.  NGROK is a service

--- a/docs/source/docfiles/markdown/workflow_yaml/farm_ai/carbon_local/carbon_whatif.md
+++ b/docs/source/docfiles/markdown/workflow_yaml/farm_ai/carbon_local/carbon_whatif.md
@@ -1,6 +1,6 @@
 # farm_ai/carbon_local/carbon_whatif
 
-Computes the offset amount of carbon that would be sequestered in a seasonal field using the baseline (historical) and scenario (time range interested in) information. To derive amount of carbon, it relies on seasonal information information provided for both baseline and scenario. The baseline represents historical information of farm practices used during each season that includes fertilizers, tillage, harvest and organic amendment. Minimum 2 years of baseline information required to execute the workflow. The scenario represents future farm practices planning to do during each season that includes fertilizers, tillage, harvest and organic amendment. For the scenario information provided, the workflow compute the offset amount of carbon that would be sequestrated in a seasonal field. Minimum 2years of baseline information required to execute the workflow. The requests received by workflow are forwarded to comet api. To know more information of comet refer to https://gitlab.com/comet-api/api-docs/-/tree/master/. To understand the enumerations and information accepted by comet refer to https://gitlab.com/comet-api/api-docs/-/blob/master/COMET-Farm_API_File_Specification.xlsx The request submitted get executed with in 5 minutes to max 2 hours. If response not received from comet within this time period, check comet_support_email for information on failed requests, if no emails received check status of requests by contacting to this support email address of comet "appnrel@colostate.edu". For public use comet limits 50 requests each day. If more requests need to send contact support email address.
+Computes the offset amount of carbon that would be sequestered in a seasonal field using the baseline (historical) and scenario (time range interested in) information. To derive amount of carbon, it relies on seasonal information information provided for both baseline and scenario. The baseline represents historical information of farm practices used during each season that includes fertilizers, tillage, harvest and organic amendment. Minimum 2 years of baseline information required to execute the workflow. The scenario represents future farm practices planned for each season and includes fertilizers, tillage, harvest and organic amendment. The requests received by workflow are forwarded to comet api. To know more information of comet refer to https://gitlab.com/comet-api/api-docs/-/tree/master/. To understand the enumerations and information accepted by comet refer to https://gitlab.com/comet-api/api-docs/-/blob/master/COMET-Farm_API_File_Specification.xlsx The request submitted get executed with in 5 minutes to max 2 hours. If response not received from comet within this time period, check comet_support_email for information on failed requests, if no emails received check status of requests by contacting to this support email address of comet "appnrel@colostate.edu". For public use comet limits 50 requests each day. If more requests need to send contact support email address.
 
 ```{mermaid}
     graph TD
@@ -17,7 +17,7 @@ Computes the offset amount of carbon that would be sequestered in a seasonal fie
 
 - **baseline_seasonal_fields**: List of seasonal fields that holds the historical information of farm practices such as fertilizers, tillage, harvest and organic amendment.
 
-- **scenario_seasonal_fields**: List of seasonal fields that holds the future information of farm practices such as fertilizers, tillage, harvest and organic amendment.
+- **scenario_seasonal_fields**: List of seasonal fields that holds future farm practices such as fertilizers, tillage, harvest and organic amendment.
 
 ## Sinks
 
@@ -26,6 +26,8 @@ Computes the offset amount of carbon that would be sequestered in a seasonal fie
 ## Parameters
 
 - **comet_support_email**: COMET-Farm API Registered email. The requests are forwarded to comet with this email reference. This email used by comet to share the information back to you for failed requests.
+
+- **comet_api_key**: COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.
 
 - **ngrok_token**: NGROK session token. FarmVibes generate web_hook url and shared url with comet along the request to receive the response from comet. It's publicly accessible url and it's unique for each session. The url gets destroyed once the session ends. To start the ngrok session a token, it is generated from this url https://dashboard.ngrok.com/
 
@@ -47,6 +49,7 @@ sinks:
   carbon_output: comet_task.carbon_output
 parameters:
   comet_support_email: null
+  comet_api_key: '@SECRET(eywa-secrets, comet-api-key)'
   ngrok_token: null
 tasks:
   comet_task:
@@ -54,6 +57,7 @@ tasks:
     op_dir: carbon_local
     parameters:
       comet_support_email: '@from(comet_support_email)'
+      comet_api_key: '@from(comet_api_key)'
       ngrok_token: '@from(ngrok_token)'
 description:
   short_description: Computes the offset amount of carbon that would be sequestered
@@ -64,11 +68,8 @@ description:
     information of farm practices used during each season that includes fertilizers,
     tillage, harvest and organic amendment. Minimum 2 years of baseline information
     required to execute the workflow. The scenario represents future farm practices
-    planning to do during each season that includes fertilizers, tillage, harvest
-    and organic amendment. For the scenario information provided, the workflow compute
-    the offset amount of carbon that would be sequestrated in a seasonal field. Minimum
-    2years of baseline information required to execute the workflow. The requests
-    received by workflow are forwarded to comet api. To know more information of comet
+    planned for each season and includes fertilizers, tillage, harvest and organic
+    amendment. The requests received by workflow are forwarded to comet api. To know more information of comet
     refer to https://gitlab.com/comet-api/api-docs/-/tree/master/. To understand the
     enumerations and information accepted by comet refer to https://gitlab.com/comet-api/api-docs/-/blob/master/COMET-Farm_API_File_Specification.xlsx
     The request submitted get executed with in 5 minutes to max 2 hours. If response
@@ -80,8 +81,8 @@ description:
   sources:
     baseline_seasonal_fields: List of seasonal fields that holds the historical information
       of farm practices such as fertilizers, tillage, harvest and organic amendment.
-    scenario_seasonal_fields: List of seasonal fields that holds the future information
-      of farm practices such as fertilizers, tillage, harvest and organic amendment.
+    scenario_seasonal_fields: List of seasonal fields that holds future farm practices
+      such as fertilizers, tillage, harvest and organic amendment.
   sinks:
     carbon_output: Carbon sequestration received for scenario information provided
       as input.
@@ -89,6 +90,8 @@ description:
     comet_support_email: COMET-Farm API Registered email. The requests are forwarded
       to comet with this email reference. This email used by comet to share the information
       back to you for failed requests.
+    comet_api_key: COMET-Farm API key, loaded from the FarmVibes.AI secret store
+      by default.
     ngrok_token: NGROK session token. FarmVibes generate web_hook url and shared url
       with comet along the request to receive the response from comet. It's publicly
       accessible url and it's unique for each session. The url gets destroyed once

--- a/notebooks/admag/azure_data_manager_for_agriculture_and_comet_farm_api_example.ipynb
+++ b/notebooks/admag/azure_data_manager_for_agriculture_and_comet_farm_api_example.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "## Define a list of objects to be retrieved from ADMAg\n",
     "\n",
-    "In the next cells, we define the `ADMAgSeasonalFieldInput` lists and the workflow parameters. Please, check the notebooks [azure_data_manager_for_agriculture_example](./azure_data_manager_for_agriculture_example.ipynb) and [carbon/whatif](../carbon/whatif.ipynb) for details related to Microsoft Azure Data Manager for Agriculture and COMET-Farm API access variables."
+    "In the next cells, we define the `ADMAgSeasonalFieldInput` lists and the workflow parameters. Please, check the notebooks [azure_data_manager_for_agriculture_example](./azure_data_manager_for_agriculture_example.ipynb) and [carbon/whatif](../carbon/whatif.ipynb) for details related to Microsoft Azure Data Manager for Agriculture and COMET-Farm API access variables. Store the COMET-Farm API key as the `comet-api-key` FarmVibes.AI secret; do not put it in this notebook."
    ]
   },
   {

--- a/notebooks/admag/azure_data_manager_for_agriculture_and_comet_farm_api_example.ipynb
+++ b/notebooks/admag/azure_data_manager_for_agriculture_and_comet_farm_api_example.ipynb
@@ -429,6 +429,19 @@
     {
      "data": {
       "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">    - <span style=\"font-weight: bold\">comet_api_key</span> (<span style=\"color: #000080; text-decoration-color: #000080\">default: @SECRET(eywa-secrets, comet-api-key)</span>): COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "    - \u001b[1mcomet_api_key\u001b[0m (\u001b[34mdefault: @SECRET(eywa-secrets, comet-api-key)\u001b[0m): COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">    - <span style=\"font-weight: bold\">ngrok_token</span> (<span style=\"color: #000080; text-decoration-color: #000080\">default: None</span>): NGROK session token. A token that FarmVibes uses to create a     \n",
        "    web_hook url that is shared with Comet in a request when running the workflow. Comet can use    \n",
        "    this link to send back a response to FarmVibes.  NGROK is a service that creates temporary urls \n",

--- a/notebooks/carbon/whatif.ipynb
+++ b/notebooks/carbon/whatif.ipynb
@@ -168,7 +168,8 @@
     "## Pre-requisites to run this notebook\n",
     "\n",
     "1. Sign up with https://comet-farm.com/. The email registered there will be used when there are error messages, or when a request fails.\n",
-    "2. Sign up with https://dashboard.ngrok.com/ to allow the TerraVibes carbon endpoint to be accessible by COMET-Farm API's webhooks.\n",
+    "2. Generate an API key on the COMET-Farm API Access page, then add it to the FarmVibes.AI secret store as `comet-api-key` by following the [secrets documentation](../../docs/source/docfiles/markdown/SECRETS.md). Do not put the key in this notebook.\n",
+    "3. Sign up with https://dashboard.ngrok.com/ to allow the TerraVibes carbon endpoint to be accessible by COMET-Farm API's webhooks.\n",
     "   1. Navigate to \"Getting Started\"/\"Your Auth token\" and copy the Auth token\n",
     "   2. Update copied auth token in variable \"NGROK_AUTH_TOKEN\" in next cell"
    ]

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -227,7 +227,7 @@ def test_whatif_request(
         os.path.dirname(os.path.abspath(__file__)), "whatif_comet_local_op.yaml"
     )
     scenario = deepcopy(fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"][0])
-    scenario["@name"] = "scenario: 17/03/2023 16:00:01"
+    scenario["@name"] = "Scenario: 17/03/2023 16:00:01"
     scenario["Carbon"]["SoilCarbon"] = "4321"
     fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"].insert(0, scenario)
     parse_comet_response.return_value = fake_comet_response

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -229,7 +229,7 @@ def test_whatif_request(
     scenario = deepcopy(fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"][0])
     scenario["@name"] = "scenario: 17/03/2023 16:00:01"
     scenario["Carbon"]["SoilCarbon"] = "4321"
-    fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"].append(scenario)
+    fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"].insert(0, scenario)
     parse_comet_response.return_value = fake_comet_response
     parameters = {
         "comet_support_email": "fake_email",

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -73,7 +73,16 @@ def baseline_information():
                     "implement": "Reduced Tillage",
                 }
             ],
-            "organic_amendments": [],
+            "organic_amendments": [
+                {
+                    "start_date": "2000-03-01T00:00:00Z",
+                    "end_date": "2000-03-01T00:00:00Z",
+                    "organic_amendment_type": "Soybean Meal",
+                    "organic_amendment_amount": 1.0,
+                    "organic_amendment_percent_nitrogen": 7.0,
+                    "organic_amendment_carbon_nitrogen_ratio": 4.0,
+                }
+            ],
         }
     ]
 
@@ -330,6 +339,7 @@ def test_comet_v25_request(
     assert cropland.findtext("Pre-1980") == "Cropland Lowland Non-Irrigated (Pre 1980s)"
     assert cropland.findtext("CRPStartYear") == "0"
     assert cropland.findtext("CRPEndYear") == "0"
+    assert cropland.findtext("Year1980-2000_Tillage") == "Full Intensive Till (III)"
     scenarios = cropland.findall("CropScenario")
     assert [scenario.attrib["Name"] for scenario in scenarios[:1]] == ["Current"]
     assert len(scenarios) == 2
@@ -344,6 +354,10 @@ def test_comet_v25_request(
         == "No Till (III)"
     )
     assert scenarios[0].find("CropYear/Crop/BioCharApplicationList") is not None
+    omad = scenarios[0].find("CropYear/Crop/OMADApplicationList/OMADApplicationEvent")
+    assert omad is not None
+    assert omad.findtext("OMADType") == "Soybean Meal"
+    assert omad.findtext("OMADApplicationMethod") == "Surface"
 
 
 def test_comet_v25_bumps_operation_version():

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -1,16 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import logging
 import os
+import xml.etree.ElementTree as ET
+from copy import deepcopy
 from datetime import datetime
-from typing import List
+from typing import Any, Dict, List
 from unittest.mock import Mock, patch
 
 import pytest
 from pyngrok.exception import PyngrokError
+from whatif_comet_local import SeasonalFieldConverter
 
 from vibe_core.data import CarbonOffsetInfo, SeasonalFieldInformation
 from vibe_dev.testing.op_tester import OpTester
+from vibe_lib.comet_farm.comet_server import CometHTTPServer, CometServerParameters
 
 
 @pytest.fixture
@@ -165,7 +170,7 @@ def fake_comet_response():
                     "@name": "sdk_int1",
                     "Scenario": [
                         {
-                            "@name": "scenario: 17/03/2023 16:00:01",
+                            "@name": "Baseline",
                             "Carbon": {
                                 "SoilCarbon": "1234.4321",
                                 "BiomassBurningCarbon": "0",
@@ -215,14 +220,19 @@ def test_whatif_request(
     _____: Mock,
     baseline_information: List[SeasonalFieldInformation],
     scenario_information: List[SeasonalFieldInformation],
-    fake_comet_response: str,
+    fake_comet_response: Dict[str, Any],
 ):
     CONFIG_PATH = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "whatif_comet_local_op.yaml"
     )
+    scenario = deepcopy(fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"][0])
+    scenario["@name"] = "scenario: 17/03/2023 16:00:01"
+    scenario["Carbon"]["SoilCarbon"] = "4321"
+    fake_comet_response["Day"]["Cropland"]["ModelRun"]["Scenario"].append(scenario)
     parse_comet_response.return_value = fake_comet_response
     parameters = {
         "comet_support_email": "fake_email",
+        "comet_api_key": "fake_api_key",
         "ngrok_token": "fake_ngrok",
     }
 
@@ -237,7 +247,7 @@ def test_whatif_request(
 
     assert "carbon_output" in output_data
     assert isinstance(output_data["carbon_output"], CarbonOffsetInfo)
-    assert "Mg Co2e/year" in output_data["carbon_output"].carbon
+    assert output_data["carbon_output"].carbon == "4321 Mg Co2e/year"
 
 
 @patch("http.server.HTTPServer.server_bind")
@@ -261,6 +271,7 @@ def test_whatif_request_comet_error(
     parse_comet_response.return_value = fake_comet_error
     parameters = {
         "comet_support_email": "fake_email",
+        "comet_api_key": "fake_api_key",
         "ngrok_token": "fake_ngrok",
     }
 
@@ -287,6 +298,7 @@ def test_whatif_start_ngrok_error(
     set_auth_token.side_effect = PyngrokError("Fake Error")
     parameters = {
         "comet_support_email": "fake_email",
+        "comet_api_key": "fake_api_key",
         "ngrok_token": "fake_ngrok",
     }
 
@@ -299,3 +311,74 @@ def test_whatif_start_ngrok_error(
             baseline_seasonal_fields=baseline_information,  # type: ignore
             scenario_seasonal_fields=scenario_information,  # type: ignore
         )
+
+
+def test_comet_v25_request(
+    baseline_information: List[SeasonalFieldInformation],
+    scenario_information: List[SeasonalFieldInformation],
+):
+    converter = SeasonalFieldConverter()
+    root = ET.fromstring(
+        converter.build_comet_request(baseline_information, scenario_information)
+    )
+
+    assert root.tag == "CometFarm"
+    assert root.find("Project/ActivityYears") is not None
+    cropland = root.find("Project/Cropland")
+    assert cropland is not None
+    assert cropland.findtext("Pre-1980") == "Cropland Lowland Non-Irrigated (Pre 1980s)"
+    assert cropland.findtext("CRPStartYear") == "0"
+    assert cropland.findtext("CRPEndYear") == "0"
+    scenarios = cropland.findall("CropScenario")
+    assert [scenario.attrib["Name"] for scenario in scenarios[:1]] == ["Current"]
+    assert len(scenarios) == 2
+    assert scenarios[0].findtext("CropYear/Crop/CropType") == "CROPS"
+    assert scenarios[0].findtext("CropYear/Crop/HarvestList/HarvestEvent/Grain") == "True"
+    assert (
+        scenarios[0].findtext("CropYear/Crop/TillageList/TillageEvent/TillageType")
+        == "Reduced Till (V)"
+    )
+    assert (
+        scenarios[1].findtext("CropYear/Crop/TillageList/TillageEvent/TillageType")
+        == "No Till (III)"
+    )
+    assert scenarios[0].find("CropYear/Crop/BioCharApplicationList") is not None
+
+    current_only = ET.fromstring(
+        converter.build_comet_request(baseline_information, [])
+    ).findall("Project/Cropland/CropScenario")
+    assert [scenario.attrib["Name"] for scenario in current_only] == ["Current"]
+
+
+@patch("vibe_lib.comet_farm.comet_server.requests.request")
+def test_submit_job_uses_api_key_without_logging_it(
+    request: Mock, caplog: pytest.LogCaptureFixture
+):
+    response = Mock()
+    request.return_value = response
+    server = Mock()
+    server.logger = logging.getLogger("test.comet")
+    server.comet_request = CometServerParameters(
+        url="https://comet-farm.com/apimain/uploadapiqueue",
+        webhook="https://callback.example",
+        supportEmail="user@example.com",
+        apiKey="secret-api-key",
+        ngrokToken="fake-ngrok-token",
+    )
+
+    with caplog.at_level(logging.INFO):
+        CometHTTPServer.submit_job(server, "<CometFarm />", "request-id")
+
+    response.raise_for_status.assert_called_once()
+    _, url = request.call_args.args
+    assert url == "https://comet-farm.com/apimain/uploadapiqueue"
+    payload = request.call_args.kwargs["data"]
+    assert payload == {
+        "email": "user@example.com",
+        "url": "https://callback.example/request-id",
+        "apikey": "secret-api-key",
+    }
+    files = request.call_args.kwargs["files"]
+    assert files["Files"][0] == "file.xml"
+    assert files["Files"][1].getvalue() == "<CometFarm />"
+    assert "secret-api-key" not in caplog.text

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 from pyngrok.exception import PyngrokError
 from whatif_comet_local import SeasonalFieldConverter
 
@@ -343,6 +344,14 @@ def test_comet_v25_request(
         == "No Till (III)"
     )
     assert scenarios[0].find("CropYear/Crop/BioCharApplicationList") is not None
+
+
+def test_comet_v25_bumps_operation_version():
+    with open(
+        os.path.join(os.path.dirname(__file__), "whatif_comet_local_op.yaml")
+    ) as config:
+        assert yaml.safe_load(config)["version"] == 3
+
 
 @patch("vibe_lib.comet_farm.comet_server.requests.request")
 def test_submit_job_uses_api_key_without_logging_it(

--- a/ops/carbon_local/test_whatif.py
+++ b/ops/carbon_local/test_whatif.py
@@ -344,12 +344,6 @@ def test_comet_v25_request(
     )
     assert scenarios[0].find("CropYear/Crop/BioCharApplicationList") is not None
 
-    current_only = ET.fromstring(
-        converter.build_comet_request(baseline_information, [])
-    ).findall("Project/Cropland/CropScenario")
-    assert [scenario.attrib["Name"] for scenario in current_only] == ["Current"]
-
-
 @patch("vibe_lib.comet_farm.comet_server.requests.request")
 def test_submit_job_uses_api_key_without_logging_it(
     request: Mock, caplog: pytest.LogCaptureFixture

--- a/ops/carbon_local/whatif_comet_local.py
+++ b/ops/carbon_local/whatif_comet_local.py
@@ -23,6 +23,18 @@ from vibe_lib.comet_farm.comet_server import HTTP_SERVER_HOST, HTTP_SERVER_PORT
 
 WEBHOOK_URL = f"http://{HTTP_SERVER_HOST}:{HTTP_SERVER_PORT}"
 
+PRE_1980_NAMES = {
+    "Irrigation (Pre 1980s)": "Cropland Irrigation (Pre 1980s)",
+    "Lowland Non-Irrigated (Pre 1980s)": "Cropland Lowland Non-Irrigated (Pre 1980s)",
+    "Upland Non-Irrigated (Pre 1980s)": "Cropland Upland Non-Irrigated (Pre 1980s)",
+}
+
+TILLAGE_NAMES = {
+    "Intensive Tillage": "Full Intensive Till (III)",
+    "Reduced Tillage": "Reduced Till (V)",
+    "Zero Soil Disturbance": "No Till (III)",
+}
+
 
 class SeasonalFieldConverter:
     def get_location(self, geojson: Dict[str, Any]):
@@ -43,10 +55,10 @@ class SeasonalFieldConverter:
         return date_obj.strftime("%m/%d/%Y")
 
     def _add_historical(self, historical_data: Dict[str, Any], cropland: ET.Element):
-        ET.SubElement(cropland, "Pre-1980").text = historical_data["pre_1980"]
-        ET.SubElement(cropland, "CRP").text = historical_data["crp_type"]
-        ET.SubElement(cropland, "CRPStartYear").text = historical_data["crp_start"]
-        ET.SubElement(cropland, "CRPEndYear").text = historical_data["crp_end"]
+        pre_1980 = historical_data["pre_1980"]
+        ET.SubElement(cropland, "Pre-1980").text = PRE_1980_NAMES.get(pre_1980, pre_1980)
+        ET.SubElement(cropland, "CRPStartYear").text = historical_data["crp_start"] or "0"
+        ET.SubElement(cropland, "CRPEndYear").text = historical_data["crp_end"] or "0"
         ET.SubElement(cropland, "CRPType").text = historical_data["crp_type"]
         ET.SubElement(cropland, "Year1980-2000").text = historical_data["year_1980_2000"]
         ET.SubElement(cropland, "Year1980-2000_Tillage").text = historical_data[
@@ -59,7 +71,7 @@ class SeasonalFieldConverter:
         harvest = ET.SubElement(harvest_list, "HarvestEvent")
 
         ET.SubElement(harvest, "HarvestDate").text = self.format_datetime(harvest_data.end_date)
-        ET.SubElement(harvest, "Grain").text = "Yes" if harvest_data.is_grain else "No"
+        ET.SubElement(harvest, "Grain").text = "True" if harvest_data.is_grain else "False"
         ET.SubElement(harvest, "yield").text = str(harvest_data.crop_yield)
         ET.SubElement(harvest, "StrawStoverHayRemoval").text = str(
             harvest_data.stray_stover_hay_removal
@@ -70,7 +82,9 @@ class SeasonalFieldConverter:
             tillage_data = TillageInformation(**tillage_data)
         tillage = ET.SubElement(tillage_list, "TillageEvent")
         ET.SubElement(tillage, "TillageDate").text = self.format_datetime(tillage_data.end_date)
-        ET.SubElement(tillage, "TillageType").text = tillage_data.implement
+        ET.SubElement(tillage, "TillageType").text = TILLAGE_NAMES.get(
+            tillage_data.implement, tillage_data.implement
+        )
 
     def _add_fertilization_information(
         self, fertilizer_data: FertilizerInformation, fertilization_list: ET.Element
@@ -82,7 +96,6 @@ class SeasonalFieldConverter:
         ET.SubElement(fertilizer, "NApplicationDate").text = fertilizer_date
         ET.SubElement(fertilizer, "NApplicationType").text = fertilizer_data.application_type
         ET.SubElement(fertilizer, "NApplicationAmount").text = str(fertilizer_data.total_nitrogen)
-        ET.SubElement(fertilizer, "NApplicationMethod").text = "Surface Band / Sidedress"
         ET.SubElement(fertilizer, "EEP").text = fertilizer_data.enhanced_efficiency_phosphorus
 
     def _add_organic_amendmentes_information(
@@ -95,7 +108,7 @@ class SeasonalFieldConverter:
         ET.SubElement(omadevent, "OMADApplicationDate").text = self.format_datetime(
             omad_data.end_date
         )
-        ET.SubElement(omadevent, "OMADType").text = omad_data.organic_amendment_type
+        ET.SubElement(omadevent, "OMADApplicationMethod").text = "Surface"
         ET.SubElement(omadevent, "OMADAmount").text = str(omad_data.organic_amendment_amount)
         ET.SubElement(omadevent, "OMADPercentN").text = str(
             omad_data.organic_amendment_percent_nitrogen
@@ -116,8 +129,11 @@ class SeasonalFieldConverter:
             "-1" if "cover" in seasonal_field.crop_type.lower() else str(crop_number)
         )
         ET.SubElement(crop, "CropName").text = seasonal_field.crop_name
+        ET.SubElement(crop, "CropType").text = "CROPS"
         # We assume SeasonalField.time_range = (plantingDate, lastHarvestDate)
-        ET.SubElement(crop, "PlantingDate").text = seasonal_field.time_range[0].strftime("%m/%d/%Y")
+        ET.SubElement(crop, "PlantingDate").text = seasonal_field.time_range[0].strftime(
+            "%m/%d/%Y 00:00:00"
+        )
         ET.SubElement(crop, "ContinueFromPreviousYear").text = "N"
 
         harvest_list = ET.SubElement(crop, "HarvestList")
@@ -145,9 +161,8 @@ class SeasonalFieldConverter:
             for omad_data in seasonal_field.organic_amendments
         ]
 
+        ET.SubElement(crop, "BioCharApplicationList")
         ET.SubElement(crop, "IrrigationList")
-
-        pass
 
     def _add_scenario(self, seasonal_fields: List[SeasonalFieldInformation], scenario: ET.Element):
         min_year = min(seasonal_fields, key=lambda x: x.time_range[0].year).time_range[0].year
@@ -164,16 +179,14 @@ class SeasonalFieldConverter:
 
     def build_comet_request(
         self,
-        support_email: str,
         baseline_seasonal_fields: List[SeasonalFieldInformation],
         scenario_seasonal_fields: List[SeasonalFieldInformation],
     ) -> str:
-        root = ET.fromstring("<Day />")
-        tree = ET.ElementTree(root)
-        root.attrib["cometEmailId"] = support_email
+        root = ET.Element("CometFarm")
+        project = ET.SubElement(root, "Project")
+        ET.SubElement(project, "ActivityYears")
 
-        cropland = ET.SubElement(root, "Cropland")
-        cropland.attrib["name"] = "sdk_int1"
+        cropland = ET.SubElement(project, "Cropland")
 
         # Baseline field
         baseline_field = baseline_seasonal_fields[0]
@@ -182,6 +195,7 @@ class SeasonalFieldConverter:
         farm_location = self.get_location(baseline_field.geometry)
 
         geom = ET.SubElement(cropland, "GEOM")
+        geom.attrib["PARCELNAME"] = "sdk_int1"
         geom.attrib["SRID"] = "4326"
         geom.attrib["AREA"] = str(farm_location[0])
         geom.text = f"POINT({farm_location[1][0]} {farm_location[1][1]})"
@@ -192,19 +206,23 @@ class SeasonalFieldConverter:
         scenario.attrib["Name"] = "Current"
         self._add_scenario(seasonal_fields=baseline_seasonal_fields, scenario=scenario)
 
-        scenario = ET.SubElement(cropland, "CropScenario")
-        scenario.attrib["Name"] = "scenario: " + datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-        self._add_scenario(seasonal_fields=scenario_seasonal_fields, scenario=scenario)
+        if scenario_seasonal_fields:
+            scenario = ET.SubElement(cropland, "CropScenario")
+            scenario.attrib["Name"] = "scenario: " + datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+            self._add_scenario(seasonal_fields=scenario_seasonal_fields, scenario=scenario)
 
-        return ET.tostring(tree.getroot(), encoding="unicode")
+        return ET.tostring(root, encoding="unicode")
 
 
 class CallbackBuilder:
-    def __init__(self, comet_url: str, comet_support_email: str, ngrok_token: str):
+    def __init__(
+        self, comet_url: str, comet_support_email: str, comet_api_key: str, ngrok_token: str
+    ):
         self.cometRequest = CometServerParameters(
             url=comet_url,
             webhook=WEBHOOK_URL,
             supportEmail=comet_support_email,
+            apiKey=comet_api_key,
             ngrokToken=ngrok_token,
         )
 
@@ -220,17 +238,18 @@ class CallbackBuilder:
     ) -> Dict[str, CarbonOffsetInfo]:
         converter = SeasonalFieldConverter()
         xml_str = converter.build_comet_request(
-            self.cometRequest.supportEmail, baseline_seasonal_fields, scenario_seasonal_fields
+            baseline_seasonal_fields, scenario_seasonal_fields
         )
 
         comet_response = self.comet_requester.run_comet_request(xml_str)
+        output_field = (scenario_seasonal_fields or baseline_seasonal_fields)[-1]
 
         obj_carbon = CarbonOffsetInfo(
             id=gen_guid(),
-            geometry=scenario_seasonal_fields[-1].geometry,
+            geometry=output_field.geometry,
             time_range=(
                 baseline_seasonal_fields[0].time_range[0],
-                scenario_seasonal_fields[-1].time_range[1],
+                output_field.time_range[1],
             ),
             assets=[],
             carbon=comet_response,

--- a/ops/carbon_local/whatif_comet_local.py
+++ b/ops/carbon_local/whatif_comet_local.py
@@ -206,10 +206,9 @@ class SeasonalFieldConverter:
         scenario.attrib["Name"] = "Current"
         self._add_scenario(seasonal_fields=baseline_seasonal_fields, scenario=scenario)
 
-        if scenario_seasonal_fields:
-            scenario = ET.SubElement(cropland, "CropScenario")
-            scenario.attrib["Name"] = "scenario: " + datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-            self._add_scenario(seasonal_fields=scenario_seasonal_fields, scenario=scenario)
+        scenario = ET.SubElement(cropland, "CropScenario")
+        scenario.attrib["Name"] = "scenario: " + datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+        self._add_scenario(seasonal_fields=scenario_seasonal_fields, scenario=scenario)
 
         return ET.tostring(root, encoding="unicode")
 
@@ -242,14 +241,12 @@ class CallbackBuilder:
         )
 
         comet_response = self.comet_requester.run_comet_request(xml_str)
-        output_field = (scenario_seasonal_fields or baseline_seasonal_fields)[-1]
-
         obj_carbon = CarbonOffsetInfo(
             id=gen_guid(),
-            geometry=output_field.geometry,
+            geometry=scenario_seasonal_fields[-1].geometry,
             time_range=(
                 baseline_seasonal_fields[0].time_range[0],
-                output_field.time_range[1],
+                scenario_seasonal_fields[-1].time_range[1],
             ),
             assets=[],
             carbon=comet_response,

--- a/ops/carbon_local/whatif_comet_local.py
+++ b/ops/carbon_local/whatif_comet_local.py
@@ -61,9 +61,10 @@ class SeasonalFieldConverter:
         ET.SubElement(cropland, "CRPEndYear").text = historical_data["crp_end"] or "0"
         ET.SubElement(cropland, "CRPType").text = historical_data["crp_type"]
         ET.SubElement(cropland, "Year1980-2000").text = historical_data["year_1980_2000"]
-        ET.SubElement(cropland, "Year1980-2000_Tillage").text = historical_data[
-            "year_1980_2000_tillage"
-        ]
+        historical_tillage = historical_data["year_1980_2000_tillage"]
+        ET.SubElement(cropland, "Year1980-2000_Tillage").text = TILLAGE_NAMES.get(
+            historical_tillage, historical_tillage
+        )
 
     def _add_harvest_information(self, harvest_data: HarvestInformation, harvest_list: ET.Element):
         if isinstance(harvest_data, dict):
@@ -108,6 +109,7 @@ class SeasonalFieldConverter:
         ET.SubElement(omadevent, "OMADApplicationDate").text = self.format_datetime(
             omad_data.end_date
         )
+        ET.SubElement(omadevent, "OMADType").text = omad_data.organic_amendment_type
         ET.SubElement(omadevent, "OMADApplicationMethod").text = "Surface"
         ET.SubElement(omadevent, "OMADAmount").text = str(omad_data.organic_amendment_amount)
         ET.SubElement(omadevent, "OMADPercentN").text = str(

--- a/ops/carbon_local/whatif_comet_local_op.yaml
+++ b/ops/carbon_local/whatif_comet_local_op.yaml
@@ -12,7 +12,7 @@ parameters:
 entrypoint:
   file: whatif_comet_local.py
   callback_builder: CallbackBuilder
-version: 2
+version: 3
 description:
   short_description:
     Computes the offset amount of carbon that would be sequestered in a seasonal field using the

--- a/ops/carbon_local/whatif_comet_local_op.yaml
+++ b/ops/carbon_local/whatif_comet_local_op.yaml
@@ -5,8 +5,9 @@ inputs:
 output:
   carbon_output: CarbonOffsetInfo
 parameters:
-  comet_url: "https://comet-farm.com/ApiMain/AddToQueue"
+  comet_url: "https://comet-farm.com/apimain/uploadapiqueue"
   comet_support_email:
+  comet_api_key: "@SECRET(eywa-secrets, comet-api-key)"
   ngrok_token:
 entrypoint:
   file: whatif_comet_local.py

--- a/src/vibe_lib/vibe_lib/comet_farm/comet_requester.py
+++ b/src/vibe_lib/vibe_lib/comet_farm/comet_requester.py
@@ -40,10 +40,9 @@ class CometRequester:
             cr = CometResponse(**comet_json)
             cLand = cr.day.cropland
             for scenario in cLand.modelRun.scenario:
-                if type(scenario) == CometOutput and "scenario" in scenario.name:
+                if isinstance(scenario, CometOutput):
                     co = CometOutput(**scenario.dict())
                     carbon_offset = co.carbon.soilCarbon + " Mg Co2e/year"
-                    break
 
             if carbon_offset is None:
                 raise RuntimeError("Missing carbon offset from COMET-Farm API")

--- a/src/vibe_lib/vibe_lib/comet_farm/comet_requester.py
+++ b/src/vibe_lib/vibe_lib/comet_farm/comet_requester.py
@@ -40,9 +40,10 @@ class CometRequester:
             cr = CometResponse(**comet_json)
             cLand = cr.day.cropland
             for scenario in cLand.modelRun.scenario:
-                if isinstance(scenario, CometOutput):
+                if isinstance(scenario, CometOutput) and "scenario" in scenario.name.lower():
                     co = CometOutput(**scenario.dict())
                     carbon_offset = co.carbon.soilCarbon + " Mg Co2e/year"
+                    break
 
             if carbon_offset is None:
                 raise RuntimeError("Missing carbon offset from COMET-Farm API")

--- a/src/vibe_lib/vibe_lib/comet_farm/comet_server.py
+++ b/src/vibe_lib/vibe_lib/comet_farm/comet_server.py
@@ -26,6 +26,7 @@ class CometServerParameters(BaseModel):
     webhook: str
     ngrokToken: str
     supportEmail: str
+    apiKey: str
 
 
 class CometHTTPServer(Thread):
@@ -60,18 +61,15 @@ class CometHTTPServer(Thread):
         webhookUrl = self.comet_request.webhook + "/" + reference_id
 
         payload = {
-            "LastCropland": "-1",
-            "FirstCropland": "-1",
             "email": self.comet_request.supportEmail,
             "url": webhookUrl,
-            "LastDaycentInput": "0",
-            "FirstDaycentInput": "0",
+            "apikey": self.comet_request.apiKey,
         }
 
-        files = {"file": ("file.xml", xml_file, "application/xml")}
+        files = {"Files": ("file.xml", xml_file, "application/xml")}
         headers = {}
 
-        self.logger.info(f"Submitting {payload} to COMET-Farm API")
+        self.logger.info("Submitting request to COMET-Farm API")
         r = requests.request("POST", postUrl, headers=headers, data=payload, files=files)
 
         # raise exception on error

--- a/workflows/farm_ai/carbon_local/admag_carbon_integration.yaml
+++ b/workflows/farm_ai/carbon_local/admag_carbon_integration.yaml
@@ -13,6 +13,7 @@ parameters:
   authority:
   default_scope:
   comet_support_email:
+  comet_api_key: "@SECRET(eywa-secrets, comet-api-key)"
   ngrok_token:
 tasks:
   baseline_seasonal_field_list:
@@ -35,6 +36,7 @@ tasks:
     workflow: farm_ai/carbon_local/carbon_whatif
     parameters:
       comet_support_email: "@from(comet_support_email)"
+      comet_api_key: "@from(comet_api_key)"
       ngrok_token: "@from(ngrok_token)"
 edges:
   - origin: baseline_seasonal_field_list.seasonal_field
@@ -70,6 +72,8 @@ description:
       Comet support email. The email used to register for a COMET account. The
       requests are forwarded to comet with this email reference.  This email is
       used by comet to share the information back to you for failed requests.
+    comet_api_key:
+      COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.
     ngrok_token:
       NGROK session token. A token that FarmVibes uses to create a web_hook url
       that is shared with Comet in a request when running the workflow. Comet

--- a/workflows/farm_ai/carbon_local/carbon_whatif.yaml
+++ b/workflows/farm_ai/carbon_local/carbon_whatif.yaml
@@ -26,9 +26,8 @@ description:
     To derive amount of carbon, it relies on seasonal information information provided for both baseline and
     scenario. The baseline represents historical information of farm practices used during each season that
     includes fertilizers, tillage, harvest and organic amendment. Minimum 2 years of baseline information required
-    to execute the workflow. The optional scenario represents future farm practices planned for each season and
-    includes fertilizers, tillage, harvest and organic amendment. Pass an empty list to receive the projected
-    baseline only. The requests received by workflow are forwarded to comet api.
+    to execute the workflow. The scenario represents future farm practices planned for each season and includes
+    fertilizers, tillage, harvest and organic amendment. The requests received by workflow are forwarded to comet api.
     To know more information of comet refer to https://gitlab.com/comet-api/api-docs/-/tree/master/.
     To understand the enumerations and information accepted by comet refer to
     https://gitlab.com/comet-api/api-docs/-/blob/master/COMET-Farm_API_File_Specification.xlsx
@@ -41,8 +40,8 @@ description:
       List of seasonal fields that holds the historical information of farm practices such as fertilizers,
       tillage, harvest and organic amendment.
     scenario_seasonal_fields:
-      Optional list of seasonal fields that holds future farm practices. Pass an empty list for a
-      projected-baseline-only request.
+      List of seasonal fields that holds future farm practices such as fertilizers, tillage, harvest and organic
+      amendment.
   sinks:
     carbon_output: Carbon sequestration received for scenario information provided as input.
   parameters:

--- a/workflows/farm_ai/carbon_local/carbon_whatif.yaml
+++ b/workflows/farm_ai/carbon_local/carbon_whatif.yaml
@@ -8,6 +8,7 @@ sinks:
   carbon_output: comet_task.carbon_output
 parameters:
   comet_support_email:
+  comet_api_key: "@SECRET(eywa-secrets, comet-api-key)"
   ngrok_token:
 tasks:
   comet_task:
@@ -15,6 +16,7 @@ tasks:
     op_dir: carbon_local
     parameters:
       comet_support_email: "@from(comet_support_email)"
+      comet_api_key: "@from(comet_api_key)"
       ngrok_token: "@from(ngrok_token)"
 description:
   short_description:
@@ -24,10 +26,9 @@ description:
     To derive amount of carbon, it relies on seasonal information information provided for both baseline and
     scenario. The baseline represents historical information of farm practices used during each season that
     includes fertilizers, tillage, harvest and organic amendment. Minimum 2 years of baseline information required
-    to execute the workflow. The scenario represents future farm practices planning to do during each season that
-    includes fertilizers, tillage, harvest and organic amendment. For the scenario information provided, the workflow
-    compute the offset amount of carbon that would be sequestrated in a seasonal field. Minimum 2years of baseline
-    information required to execute the workflow. The requests received by workflow are forwarded to comet api.
+    to execute the workflow. The optional scenario represents future farm practices planned for each season and
+    includes fertilizers, tillage, harvest and organic amendment. Pass an empty list to receive the projected
+    baseline only. The requests received by workflow are forwarded to comet api.
     To know more information of comet refer to https://gitlab.com/comet-api/api-docs/-/tree/master/.
     To understand the enumerations and information accepted by comet refer to
     https://gitlab.com/comet-api/api-docs/-/blob/master/COMET-Farm_API_File_Specification.xlsx
@@ -40,14 +41,16 @@ description:
       List of seasonal fields that holds the historical information of farm practices such as fertilizers,
       tillage, harvest and organic amendment.
     scenario_seasonal_fields:
-      List of seasonal fields that holds the future information of farm practices such as fertilizers,
-      tillage, harvest and organic amendment.
+      Optional list of seasonal fields that holds future farm practices. Pass an empty list for a
+      projected-baseline-only request.
   sinks:
     carbon_output: Carbon sequestration received for scenario information provided as input.
   parameters:
     comet_support_email:
       COMET-Farm API Registered email. The requests are forwarded to comet with this email reference.
       This email used by comet to share the information back to you for failed requests.
+    comet_api_key:
+      COMET-Farm API key, loaded from the FarmVibes.AI secret store by default.
     ngrok_token:
       NGROK session token. FarmVibes generate web_hook url and shared url with comet along the request to receive the
       response from comet. It's publicly accessible url and it's unique for each session. The url gets destroyed


### PR DESCRIPTION
COMET-Farm v2.5 changed the queue endpoint, made `apikey` mandatory, and updated several XML values. The current integration still sends the old request, which explains the persistent 500 in #199.

This PR updates the endpoint and multipart payload, loads the API key from the existing FarmVibes secret mechanism, and aligns the request XML with v2.5. Baseline and future scenario inputs remain required; the separate ngrok lifecycle work in #228 is unchanged. Sanitized tests cover the payload, schema, response selection, cache-version bump, and ensure the key is not logged.

Closes #199.