### PR TITLE
Fix documentation publishing workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,38 +1,47 @@
 name: Build FarmVibes.AI documentation
 run-name: Generate documentation html pages
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    types: [closed]
     branches:
       - main
   workflow_dispatch:
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true || contains(fromJSON('["workflow_dispatch"]'), github.event_name)
+  build:
     name: Build documentation
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Update pip version
-        shell: bash
-        run: pip install --upgrade pip
-
-      ### Build docs with sphinx
-      - name: Build documentation pages
-        uses: ammaraskar/sphinx-action@master
+      - name: Checkout gh-pages
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          docs-folder: "docs/"
-          pre-build-command: "pip install --user ./src/vibe_core"
+          ref: gh-pages
+          path: gh-pages
 
-      # Publish built docs to gh-pages branch
-      - name: Publish to gh-pages
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install documentation dependencies
         run: |
-          git clone https://github.com/microsoft/farmvibes-ai.git --branch gh-pages --single-branch gh-pages
+          pip install --upgrade pip
+          pip install ./src/vibe_core
+          pip install -r docs/requirements.txt
+
+      - name: Build documentation pages
+        run: make -C docs html
+
+      - name: Publish to gh-pages
+        if: github.event_name != 'pull_request'
+        run: |
           cp -r docs/build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
@@ -40,11 +49,4 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add .
           git commit -m "Update documentation" -a || true
-          # The above command will fail if no changes were present, so we ignore that.
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git push origin HEAD:gh-pages


### PR DESCRIPTION
The documentation workflow currently publishes on a closed pull-request event, but that event receives a read-only token. The documentation build succeeds and the final gh-pages push fails with 403.

This PR builds documentation on pull requests without publishing, then publishes only after changes reach main. It also removes the mutable third-party master actions in favor of direct Sphinx commands and immutable official action SHAs.